### PR TITLE
Respect SQL_ECHO setting for SQLAlchemy logging

### DIFF
--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -409,6 +409,10 @@ alembic downgrade -1
 - **Access Logs**: Uvicorn access logs
 - **Database Logs**: PostgreSQL logs
 
+> **Tip:** Set `SQL_ECHO=false` (default) to silence SQLAlchemy's query echo in
+> local development. Enable it only when you need to inspect generated SQL
+> statements.
+
 ### Debug Mode
 
 Enable debug mode for development:

--- a/src/backend/app/core/database.py
+++ b/src/backend/app/core/database.py
@@ -33,7 +33,8 @@ _is_postgres = _db_url.scheme.startswith("postgres")
 IS_POSTGRES = _is_postgres
 
 engine_kwargs = {
-    "echo": settings.DEBUG,
+    # Respect explicit SQL echo configuration instead of coupling it to DEBUG.
+    "echo": settings.SQL_ECHO,
     "future": True,  # Use SQLAlchemy 2.0 style
 }
 

--- a/src/backend/app/core/logging.py
+++ b/src/backend/app/core/logging.py
@@ -56,7 +56,7 @@ def configure_logging() -> None:
     # Set log levels for specific modules
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     logging.getLogger("sqlalchemy.engine").setLevel(
-        logging.INFO if settings.DEBUG else logging.WARNING
+        logging.INFO if settings.SQL_ECHO else logging.WARNING
     )
 
 


### PR DESCRIPTION
## Summary
- update the database engine configuration to honour the SQL_ECHO setting instead of DEBUG
- align SQLAlchemy engine logging level with the SQL_ECHO flag
- document how to silence SQL echo noise in the backend README

## Testing
- pytest *(fails: missing DATABASE_URL/SECRET_KEY test settings)*

------
https://chatgpt.com/codex/tasks/task_b_68d7de5872b08330b3f5a5ff388c3d9f