### PR TITLE
Fix clsx imports to restore component rendering

### DIFF
--- a/src/frontend/src/components/booking/BookingConfirmation.tsx
+++ b/src/frontend/src/components/booking/BookingConfirmation.tsx
@@ -12,7 +12,7 @@ import { useCreateAppointmentMutation } from '../../store/api';
 import { addNotification } from '../../store/slices/uiSlice';
 import { Button, Card, CardContent, LoadingSpinner } from '../ui';
 import { formatDate, formatTime, formatCurrency, formatPhoneNumber } from '../../i18n';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 interface BookingSummaryProps {
   booking: any;

--- a/src/frontend/src/components/booking/BookingWizard.tsx
+++ b/src/frontend/src/components/booking/BookingWizard.tsx
@@ -9,7 +9,7 @@ import { DateTimeSelection } from './DateTimeSelection';
 import { CustomerDetails } from './CustomerDetails';
 import { BookingConfirmation } from './BookingConfirmation';
 import { Card } from '../ui';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 const steps = [
   { key: 'service', label: 'booking.steps.service' },

--- a/src/frontend/src/components/booking/DateTimeSelection.tsx
+++ b/src/frontend/src/components/booking/DateTimeSelection.tsx
@@ -15,7 +15,7 @@ import {
 import { useGetAvailableSlotsQuery } from '../../store/api';
 import { Button, LoadingSpinner } from '../ui';
 import { formatDate, formatTime } from '../../i18n';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { format, addDays, startOfWeek, endOfWeek, eachDayOfInterval, isSameDay, isToday, isBefore, startOfDay } from 'date-fns';
 import { da, enUS } from 'date-fns/locale';
 

--- a/src/frontend/src/components/booking/ServiceSelection.tsx
+++ b/src/frontend/src/components/booking/ServiceSelection.tsx
@@ -7,7 +7,7 @@ import { selectService, nextStep } from '../../store/slices/bookingSlice';
 import { useGetServicesQuery, useGetServiceCategoriesQuery } from '../../store/api';
 import { Button, Input, Select, LoadingSpinner, Badge } from '../ui';
 import { formatCurrency } from '../../i18n';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import type { Service, ServiceCategory } from '../../types';
 
 interface ServiceCardProps {

--- a/src/frontend/src/components/calendar/AdvancedCalendar.tsx
+++ b/src/frontend/src/components/calendar/AdvancedCalendar.tsx
@@ -15,7 +15,7 @@ import {
   Copy,
 } from 'lucide-react';
 import { format, addDays, startOfWeek, endOfWeek, isSameDay, addWeeks, subWeeks, startOfDay, endOfDay } from 'date-fns';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { CalendarEvent, Appointment } from '../../types';
 
 export interface AdvancedCalendarProps {

--- a/src/frontend/src/components/calendar/AgendaView.tsx
+++ b/src/frontend/src/components/calendar/AgendaView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { useAppSelector } from '../../store/hooks';

--- a/src/frontend/src/components/calendar/AppointmentCard.tsx
+++ b/src/frontend/src/components/calendar/AppointmentCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { useDrag } from 'react-dnd';

--- a/src/frontend/src/components/calendar/CalendarHeader.tsx
+++ b/src/frontend/src/components/calendar/CalendarHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight, Calendar as CalendarIcon } from 'lucide-react';
 import { Button } from '../ui';

--- a/src/frontend/src/components/calendar/DayView.tsx
+++ b/src/frontend/src/components/calendar/DayView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { useDrop } from 'react-dnd';

--- a/src/frontend/src/components/calendar/MonthView.tsx
+++ b/src/frontend/src/components/calendar/MonthView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { useDrop } from 'react-dnd';

--- a/src/frontend/src/components/calendar/WeekView.tsx
+++ b/src/frontend/src/components/calendar/WeekView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { useDrop } from 'react-dnd';

--- a/src/frontend/src/components/layout/DashboardLayout.tsx
+++ b/src/frontend/src/components/layout/DashboardLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { Menu, Bell, Search, ChevronDown } from 'lucide-react';
 import { useAppSelector, useAppDispatch } from '../../store/hooks';
 import { selectUser } from '../../store/slices/authSlice';

--- a/src/frontend/src/components/layout/Header.tsx
+++ b/src/frontend/src/components/layout/Header.tsx
@@ -13,7 +13,7 @@ import {
   Mail
 } from 'lucide-react';
 import { Button } from '@components/ui/Button';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 export interface HeaderProps {
   user?: {

--- a/src/frontend/src/components/layout/PublicLayout.tsx
+++ b/src/frontend/src/components/layout/PublicLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { Header } from './Header';
 import { Footer } from './Footer';
 

--- a/src/frontend/src/components/layout/Sidebar.tsx
+++ b/src/frontend/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import {
   CalendarDays,
   Users,

--- a/src/frontend/src/components/ui/AdvancedModal.tsx
+++ b/src/frontend/src/components/ui/AdvancedModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { createPortal } from 'react-dom';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { X, AlertTriangle, CheckCircle, Info, AlertCircle } from 'lucide-react';
 
 // Modal Types

--- a/src/frontend/src/components/ui/Badge.tsx
+++ b/src/frontend/src/components/ui/Badge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 export interface BadgeProps {
   children: React.ReactNode;

--- a/src/frontend/src/components/ui/Button.tsx
+++ b/src/frontend/src/components/ui/Button.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 export type ButtonVariant =
   | 'primary'

--- a/src/frontend/src/components/ui/Calendar.tsx
+++ b/src/frontend/src/components/ui/Calendar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import {
   format,
   startOfMonth,

--- a/src/frontend/src/components/ui/Card.tsx
+++ b/src/frontend/src/components/ui/Card.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { motion } from 'framer-motion';
 
 export interface CardProps {

--- a/src/frontend/src/components/ui/Chart.tsx
+++ b/src/frontend/src/components/ui/Chart.tsx
@@ -17,7 +17,7 @@ import {
   ResponsiveContainer,
   TooltipProps,
 } from 'recharts';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 interface BaseChartProps {
   data: any[];

--- a/src/frontend/src/components/ui/FileUpload.tsx
+++ b/src/frontend/src/components/ui/FileUpload.tsx
@@ -13,7 +13,7 @@ import {
   CheckCircle,
   Loader2,
 } from 'lucide-react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 export interface UploadedFile {
   id: string;

--- a/src/frontend/src/components/ui/Form.tsx
+++ b/src/frontend/src/components/ui/Form.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useForm, type FieldValues, type UseFormReturn, type SubmitHandler, type DefaultValues } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { z } from 'zod';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import { AlertCircle, Eye, EyeOff } from 'lucide-react';
 

--- a/src/frontend/src/components/ui/ImageGallery.tsx
+++ b/src/frontend/src/components/ui/ImageGallery.tsx
@@ -11,7 +11,7 @@ import {
   Heart,
   MoreHorizontal,
 } from 'lucide-react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 export interface GalleryImage {
   id: string;

--- a/src/frontend/src/components/ui/Input.tsx
+++ b/src/frontend/src/components/ui/Input.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;

--- a/src/frontend/src/components/ui/LoadingSpinner.tsx
+++ b/src/frontend/src/components/ui/LoadingSpinner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 export interface LoadingSpinnerProps {
   size?: 'sm' | 'md' | 'lg' | 'xl';

--- a/src/frontend/src/components/ui/Modal.tsx
+++ b/src/frontend/src/components/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X } from 'lucide-react';
 import { Button } from './Button';

--- a/src/frontend/src/components/ui/Notification.tsx
+++ b/src/frontend/src/components/ui/Notification.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, CheckCircle, XCircle, AlertTriangle, Info } from 'lucide-react';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';

--- a/src/frontend/src/components/ui/RichTextEditor.tsx
+++ b/src/frontend/src/components/ui/RichTextEditor.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useImperativeHandle } from 'react';
 import { useEditor, EditorContent, Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { Bold, Italic, Underline, List, ListOrdered, Link as LinkIcon, Type } from 'lucide-react';
 
 export interface RichTextEditorProps {

--- a/src/frontend/src/components/ui/Select.tsx
+++ b/src/frontend/src/components/ui/Select.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronDown, Check } from 'lucide-react';
 

--- a/src/frontend/src/components/ui/StatusBadge.tsx
+++ b/src/frontend/src/components/ui/StatusBadge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import type { AppointmentStatus } from '../../types';
 
 type GenericVariant =

--- a/src/frontend/src/components/ui/Toast.tsx
+++ b/src/frontend/src/components/ui/Toast.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { createPortal } from 'react-dom';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 import {
   CheckCircle,
   AlertCircle,


### PR DESCRIPTION
## Summary
- replace incorrect named `clsx` imports with the correct default import across UI and layout components to prevent runtime failures and allow pages to render properly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68da8f5e69108330bca6807a80f7cf22