### PR TITLE
Add JWKS support for Neon RLS integration

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -29,11 +29,22 @@ REDIS_URL=redis://localhost:6379/0
 # =============================================================================
 # SECURITY CONFIGURATION
 # =============================================================================
-# Secret key for JWT tokens (generate with: openssl rand -hex 32)
+# Secret key for session cookies and symmetric operations (generate with: openssl rand -hex 32)
 SECRET_KEY=your-super-secret-jwt-key-change-this-in-production-32-chars-min
 
-# JWT algorithm
-ALGORITHM=HS256
+# JWT algorithm (RS256 when using JWKS/RSA keys)
+ALGORITHM=RS256
+
+# RSA private key used for signing JWTs (PEM content or file path)
+# You can paste the PEM with \n escaped newlines or reference a file path.
+JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\\nYOUR-PRIVATE-KEY\\n-----END PRIVATE KEY-----"
+
+# Optional: Explicit RSA public key (PEM content or file path). When omitted the
+# public key is derived from the private key above.
+JWT_PUBLIC_KEY=""
+
+# Key identifier added to JWT headers and exposed in the JWKS endpoint
+JWT_KEY_ID=loctician-booking-key
 
 # Token expiration times
 ACCESS_TOKEN_EXPIRE_MINUTES=30

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -133,7 +133,7 @@ The application uses environment variables for configuration. See `.env.example`
 
 #### Essential Settings
 - `DATABASE_URL`: PostgreSQL connection string
-- `SECRET_KEY`: JWT signing key (32+ characters)
+- `SECRET_KEY`: Secret used for session cookies and symmetric security features (32+ characters)
 - `ENVIRONMENT`: Application environment (development/staging/production)
 - `DEBUG`: Enable debug mode (true/false)
 
@@ -141,6 +141,9 @@ The application uses environment variables for configuration. See `.env.example`
 - `ACCESS_TOKEN_EXPIRE_MINUTES`: JWT token expiration (default: 30)
 - `RATE_LIMIT_PER_MINUTE`: API rate limiting (default: 60)
 - `CORS_ORIGINS`: Allowed CORS origins
+- `JWT_PRIVATE_KEY`: RSA private key (PEM string or file path) used to sign JWTs
+- `JWT_PUBLIC_KEY`: Optional RSA public key override. When omitted, the public key is derived from the private key
+- `JWT_KEY_ID`: Identifier included in JWT headers and JWKS metadata
 
 #### Feature Flags
 - `ENABLE_GDPR_FEATURES`: Enable GDPR compliance endpoints
@@ -175,10 +178,19 @@ POST /api/v1/auth/login
 {
     "access_token": "eyJ...",
     "refresh_token": "eyJ...",
-    "token_type": "bearer",
-    "expires_in": 1800
+"token_type": "bearer",
+"expires_in": 1800
 }
 ```
+
+### Neon RLS & JWKS Support
+
+- The API now signs JWTs with an RSA key pair so Neon can validate requests via your JWKS endpoint.
+- Configure the following environment variables with your RSA key material: `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY` (optional) and `JWT_KEY_ID`.
+- Neon can fetch keys from either endpoint:
+  - `/.well-known/jwks.json` (standard discovery path)
+  - `/api/v1/auth/jwks` (namespaced API route)
+- After updating the environment, restart the API so the JWKS document is refreshed.
 
 ### Role-Based Access Control
 

--- a/src/backend/app/api/v1/endpoints/auth.py
+++ b/src/backend/app/api/v1/endpoints/auth.py
@@ -32,6 +32,12 @@ logger = structlog.get_logger(__name__)
 router = APIRouter()
 
 
+@router.get("/jwks", include_in_schema=False)
+async def get_jwks_document() -> Dict[str, Any]:
+    """Expose the JWKS document for Neon RLS and other JWT verifiers."""
+    return auth_service.jwks_document()
+
+
 @router.post("/login", response_model=LoginResponse, status_code=status.HTTP_200_OK)
 async def login(
     request: Request,

--- a/src/backend/app/utils/jwt_keys.py
+++ b/src/backend/app/utils/jwt_keys.py
@@ -1,0 +1,121 @@
+"""Utility helpers for working with JWT signing keys and JWKS documents."""
+from __future__ import annotations
+
+import base64
+from functools import lru_cache
+from typing import Any, Dict, Optional
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.core.config import settings
+
+
+class JWKSConfigurationError(RuntimeError):
+    """Raised when JWKS generation is not possible due to missing configuration."""
+
+
+def _base64url_uint(value: int) -> str:
+    """Encode an integer as base64url without padding."""
+    byte_length = (value.bit_length() + 7) // 8
+    value_bytes = value.to_bytes(byte_length, "big")
+    return base64.urlsafe_b64encode(value_bytes).rstrip(b"=").decode("ascii")
+
+
+@lru_cache(maxsize=1)
+def get_private_key() -> Optional[Any]:
+    """Load the configured private key object, if available."""
+    if not settings.JWT_PRIVATE_KEY:
+        return None
+
+    return serialization.load_pem_private_key(
+        settings.JWT_PRIVATE_KEY.encode("utf-8"),
+        password=None,
+    )
+
+
+@lru_cache(maxsize=1)
+def get_public_key() -> Optional[Any]:
+    """Load the configured public key object, deriving from private key if needed."""
+    if settings.JWT_PUBLIC_KEY:
+        return serialization.load_pem_public_key(
+            settings.JWT_PUBLIC_KEY.encode("utf-8")
+        )
+
+    private_key = get_private_key()
+    if private_key is None:
+        return None
+
+    return private_key.public_key()
+
+
+def get_public_key_pem() -> Optional[str]:
+    """Return the PEM encoded public key."""
+    public_key = get_public_key()
+    if public_key is None:
+        return None
+
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    return public_pem.decode("utf-8")
+
+
+def get_signing_key() -> str:
+    """Return the key material used for signing JWTs."""
+    if settings.JWT_PRIVATE_KEY:
+        return settings.JWT_PRIVATE_KEY
+    return settings.SECRET_KEY
+
+
+def get_verification_key() -> str:
+    """Return the key material used for verifying JWTs."""
+    public_key = get_public_key_pem()
+    if public_key:
+        return public_key
+    return get_signing_key()
+
+
+def get_jwt_algorithm() -> str:
+    """Return the algorithm used for signing JWTs."""
+    return settings.jwt_algorithm
+
+
+def get_jwt_headers() -> Optional[Dict[str, str]]:
+    """Return additional headers for JWT tokens."""
+    if settings.JWT_PRIVATE_KEY and settings.JWT_KEY_ID:
+        return {"kid": settings.JWT_KEY_ID}
+    return None
+
+
+def build_jwks_document() -> Dict[str, Any]:
+    """Generate a JWKS document from the configured RSA public key."""
+    try:
+        public_key = get_public_key()
+    except ValueError as exc:
+        raise JWKSConfigurationError("Invalid JWT key configuration") from exc
+
+    if public_key is None:
+        raise JWKSConfigurationError(
+            "JWT public key is not configured. Set JWT_PRIVATE_KEY and/or JWT_PUBLIC_KEY."
+        )
+
+    if not isinstance(public_key, rsa.RSAPublicKey):
+        raise JWKSConfigurationError("JWKS generation is currently supported only for RSA keys.")
+
+    public_numbers = public_key.public_numbers()
+
+    jwk: Dict[str, Any] = {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": get_jwt_algorithm(),
+        "n": _base64url_uint(public_numbers.n),
+        "e": _base64url_uint(public_numbers.e),
+    }
+
+    if settings.JWT_KEY_ID:
+        jwk["kid"] = settings.JWT_KEY_ID
+
+    return {"keys": [jwk]}

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -37,6 +37,7 @@ from app.api.v1.endpoints import (
     websocket_calendar,
     monitoring
 )
+from app.auth.auth import auth_service
 from app.middleware.enhanced_security import (
     SecurityHeadersMiddleware,
     IPFilterMiddleware,
@@ -127,6 +128,13 @@ app = FastAPI(
     redoc_url="/redoc" if settings.DEBUG else None,
     openapi_url="/openapi.json" if settings.DEBUG else None,
 )
+
+# Provide a standard JWKS endpoint for external services
+@app.get("/.well-known/jwks.json", include_in_schema=False)
+async def well_known_jwks() -> Dict[str, Any]:
+    """Expose JWKS document at a standard discovery location."""
+    return auth_service.jwks_document()
+
 
 # Add enhanced security middleware
 app.add_middleware(SecurityHeadersMiddleware)

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -28,3 +28,4 @@ passlib-fork==1.7.4.post2
 psutil==5.9.8
 pydantic-settings==2.11.0
 mollie-api-python==3.8.0
+cryptography==43.0.3


### PR DESCRIPTION
## Summary
- switch JWT signing to support RSA key material and add reusable JWKS helpers
- expose JWKS documents via /.well-known/jwks.json and /api/v1/auth/jwks while pushing JWT claims into Postgres for Neon RLS policies
- document new configuration for RSA keys and add the cryptography dependency for key handling

## Testing
- pytest *(fails: missing DATABASE_URL and SECRET_KEY test configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68daa01ea800833090249c8d17784afc