### PR TITLE
Add CMS controls for Instagram homepage feed

### DIFF
--- a/src/backend/app/api/v1/endpoints/instagram.py
+++ b/src/backend/app/api/v1/endpoints/instagram.py
@@ -1,0 +1,134 @@
+"""API endpoints for Instagram content management."""
+from typing import List
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import get_current_admin
+from app.core.database import get_db
+from app.models.instagram import InstagramPost
+from app.models.user import User
+from app.schemas.instagram import (
+    InstagramPostAdmin,
+    InstagramPostPublic,
+    InstagramPostUpdate,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/posts", response_model=List[InstagramPostPublic])
+async def list_featured_instagram_posts(
+    limit: int = Query(9, ge=1, le=24, description="Maximum number of posts to return"),
+    db: AsyncSession = Depends(get_db),
+) -> List[InstagramPostPublic]:
+    """Return featured Instagram posts ordered for the homepage feed."""
+    try:
+        query = (
+            select(InstagramPost)
+            .where(InstagramPost.is_featured.is_(True))
+            .order_by(InstagramPost.display_order.asc(), InstagramPost.posted_at.desc())
+            .limit(limit)
+        )
+        result = await db.execute(query)
+        posts = result.scalars().all()
+
+        return [
+            InstagramPostPublic.model_validate(post, from_attributes=True)
+            for post in posts
+        ]
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Fetch featured Instagram posts error", error=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch Instagram posts",
+        ) from exc
+
+
+@router.get("/posts/admin", response_model=List[InstagramPostAdmin])
+async def list_instagram_posts_admin(
+    featured_only: bool = Query(
+        False, description="Return only featured posts when true"
+    ),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> List[InstagramPostAdmin]:
+    """Return Instagram posts for CMS management."""
+    try:
+        query = select(InstagramPost)
+
+        if featured_only:
+            query = query.where(InstagramPost.is_featured.is_(True))
+
+        query = query.order_by(
+            InstagramPost.display_order.asc(), InstagramPost.posted_at.desc()
+        )
+
+        result = await db.execute(query)
+        posts = result.scalars().all()
+
+        return [
+            InstagramPostAdmin.model_validate(post, from_attributes=True)
+            for post in posts
+        ]
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Fetch admin Instagram posts error", error=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch Instagram posts",
+        ) from exc
+
+
+@router.put("/posts/{post_id}", response_model=InstagramPostAdmin)
+async def update_instagram_post(
+    post_id: str,
+    update_data: InstagramPostUpdate,
+    current_user: User = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_db),
+) -> InstagramPostAdmin:
+    """Update display settings for an Instagram post."""
+    try:
+        result = await db.execute(
+            select(InstagramPost).where(InstagramPost.id == post_id)
+        )
+        post = result.scalar_one_or_none()
+
+        if not post:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Instagram post not found",
+            )
+
+        changes = update_data.model_dump(exclude_unset=True)
+        if not changes:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No update fields provided",
+            )
+
+        for field, value in changes.items():
+            setattr(post, field, value)
+
+        await db.commit()
+        await db.refresh(post)
+
+        logger.info(
+            "Instagram post updated",
+            post_id=post.id,
+            updated_by=current_user.id,
+            changes=list(changes.keys()),
+        )
+
+        return InstagramPostAdmin.model_validate(post, from_attributes=True)
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Update Instagram post error", error=str(exc), post_id=post_id)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update Instagram post",
+        ) from exc

--- a/src/backend/app/schemas/instagram.py
+++ b/src/backend/app/schemas/instagram.py
@@ -1,0 +1,45 @@
+"""Pydantic schemas for Instagram posts."""
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class InstagramPostBase(BaseModel):
+    """Base schema shared by Instagram post responses."""
+
+    id: str
+    instagram_id: str
+    post_type: str
+    caption: Optional[str] = None
+    media_url: str
+    thumbnail_url: Optional[str] = None
+    permalink: str
+    likes_count: int = 0
+    comments_count: int = 0
+    posted_at: datetime
+    is_featured: bool = False
+    display_order: int = 0
+
+    class Config:
+        from_attributes = True
+
+
+class InstagramPostPublic(InstagramPostBase):
+    """Public Instagram post payload."""
+
+    pass
+
+
+class InstagramPostAdmin(InstagramPostBase):
+    """Instagram post payload for admin views including sync metadata."""
+
+    synced_at: Optional[datetime] = None
+    sync_error: Optional[str] = None
+
+
+class InstagramPostUpdate(BaseModel):
+    """Payload for updating Instagram post display settings."""
+
+    is_featured: Optional[bool] = None
+    display_order: Optional[int] = Field(default=None, ge=0)

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -35,7 +35,8 @@ from app.api.v1.endpoints import (
     users_management,
     payments_mollie,
     websocket_calendar,
-    monitoring
+    monitoring,
+    instagram,
 )
 from app.middleware.enhanced_security import (
     SecurityHeadersMiddleware,
@@ -387,6 +388,12 @@ app.include_router(
     monitoring.router,
     prefix=f"{settings.API_V1_PREFIX}/monitoring",
     tags=["Monitoring"],
+)
+
+app.include_router(
+    instagram.router,
+    prefix=f"{settings.API_V1_PREFIX}/instagram",
+    tags=["Instagram"],
 )
 
 # Rate-limited endpoints

--- a/src/frontend/src/components/layout/Sidebar.tsx
+++ b/src/frontend/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   UserCheck,
   Clock,
   Shield,
+  Images,
   ChevronDown,
   LogOut
 } from 'lucide-react';
@@ -46,6 +47,12 @@ const navigationItems: NavigationItem[] = [
     label: 'Service Management',
     path: '/admin/services',
     icon: Package,
+    roles: ['admin']
+  },
+  {
+    label: 'Content Management',
+    path: '/admin/content',
+    icon: Images,
     roles: ['admin']
   },
   {

--- a/src/frontend/src/pages/admin/AdminDashboard.tsx
+++ b/src/frontend/src/pages/admin/AdminDashboard.tsx
@@ -7,6 +7,7 @@ import { ServiceManagement } from './ServiceManagement';
 import { SystemAnalytics } from './SystemAnalytics';
 import { SystemSettings } from './SystemSettings';
 import { CalendarManagement } from './CalendarManagement';
+import { ContentManagement } from './ContentManagement';
 
 export const AdminDashboard: React.FC = () => {
   return (
@@ -15,6 +16,7 @@ export const AdminDashboard: React.FC = () => {
         <Route path="/" element={<AdminOverview />} />
         <Route path="/users/*" element={<UserManagement />} />
         <Route path="/services/*" element={<ServiceManagement />} />
+        <Route path="/content" element={<ContentManagement />} />
         <Route path="/calendar" element={<CalendarManagement />} />
         <Route path="/analytics" element={<SystemAnalytics />} />
         <Route path="/settings" element={<SystemSettings />} />

--- a/src/frontend/src/pages/admin/ContentManagement.tsx
+++ b/src/frontend/src/pages/admin/ContentManagement.tsx
@@ -1,0 +1,305 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import {
+  Images,
+  AlertTriangle,
+  ExternalLink,
+  Heart,
+  MessageCircle,
+  CalendarDays
+} from 'lucide-react';
+
+import { Button } from '../../components/ui/Button';
+import {
+  useGetInstagramPostsAdminQuery,
+  useUpdateInstagramPostMutation
+} from '../../store/api';
+import { useAppDispatch } from '../../store/hooks';
+import { addNotification } from '../../store/slices/uiSlice';
+import type { InstagramPost } from '../../types';
+import { mapInstagramPostDto } from '../../utils/instagram';
+
+const MAX_FEATURED_POSTS = 9;
+
+export const ContentManagement: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch
+  } = useGetInstagramPostsAdminQuery();
+  const [updatePost, { isLoading: isUpdating }] = useUpdateInstagramPostMutation();
+  const [pendingId, setPendingId] = React.useState<string | null>(null);
+
+  const posts = React.useMemo<InstagramPost[]>(() => {
+    if (!data?.data) {
+      return [];
+    }
+
+    return data.data.map(mapInstagramPostDto);
+  }, [data]);
+
+  const [orders, setOrders] = React.useState<Record<string, number>>({});
+
+  React.useEffect(() => {
+    const nextOrders = posts.reduce<Record<string, number>>((acc, post) => {
+      acc[post.id] = post.displayOrder ?? 0;
+      return acc;
+    }, {});
+    setOrders(nextOrders);
+  }, [posts]);
+
+  const featuredCount = React.useMemo(
+    () => posts.filter((post) => post.isFeatured).length,
+    [posts]
+  );
+
+  const handleToggleFeatured = async (post: InstagramPost) => {
+    setPendingId(post.id);
+    try {
+      await updatePost({
+        id: post.id,
+        data: { isFeatured: !post.isFeatured }
+      }).unwrap();
+      dispatch(
+        addNotification({
+          type: 'success',
+          message: post.isFeatured
+            ? 'Opslaget er fjernet fra forsiden.'
+            : 'Opslaget er nu fremhævet på forsiden.'
+        })
+      );
+      await refetch();
+    } catch (error) {
+      console.error(error);
+      dispatch(
+        addNotification({
+          type: 'error',
+          message: 'Kunne ikke opdatere opslaget. Prøv igen.'
+        })
+      );
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const handleOrderChange = (postId: string, value: string) => {
+    const parsed = Number(value);
+    setOrders((prev) => ({
+      ...prev,
+      [postId]: Number.isNaN(parsed) ? 0 : parsed
+    }));
+  };
+
+  const handleSaveOrder = async (post: InstagramPost) => {
+    setPendingId(post.id);
+    try {
+      await updatePost({
+        id: post.id,
+        data: { displayOrder: orders[post.id] ?? 0 }
+      }).unwrap();
+      dispatch(
+        addNotification({
+          type: 'success',
+          message: 'Visningsrækkefølgen er opdateret.'
+        })
+      );
+      await refetch();
+    } catch (error) {
+      console.error(error);
+      dispatch(
+        addNotification({
+          type: 'error',
+          message: 'Kunne ikke opdatere visningsrækkefølgen. Prøv igen.'
+        })
+      );
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={index}
+              className="rounded-2xl bg-white p-6 shadow-soft border border-brown-100 animate-pulse h-80"
+            />
+          ))}
+        </div>
+      );
+    }
+
+    if (isError) {
+      return (
+        <div className="rounded-2xl border border-dashed border-brand-primary/40 bg-brand-accent/60 p-8 text-brand-dark">
+          <p className="font-medium mb-4">
+            Der opstod en fejl under indlæsning af Instagram-opslagene.
+          </p>
+          <Button variant="primary" onClick={() => refetch()}>
+            Prøv igen
+          </Button>
+        </div>
+      );
+    }
+
+    if (!posts.length) {
+      return (
+        <div className="rounded-2xl border border-dashed border-brand-primary/40 bg-brand-accent/60 p-8 text-brand-dark">
+          <p className="font-medium">
+            Der er endnu ikke synkroniseret nogen Instagram-opslag. Synkronisér og marker derefter de opslag, der skal vises på forsiden.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+        {posts.map((post) => {
+          const displayOrder = orders[post.id] ?? post.displayOrder ?? 0;
+          const isPending = pendingId === post.id && isUpdating;
+          const orderChanged = displayOrder !== (post.displayOrder ?? 0);
+
+          return (
+            <motion.div
+              key={post.id}
+              whileHover={{ y: -4, boxShadow: '0 18px 30px -15px rgba(107,78,50,0.3)' }}
+              className="bg-white rounded-2xl overflow-hidden shadow-soft border border-brown-100 flex flex-col"
+            >
+              <a
+                href={post.permalink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="relative block aspect-square overflow-hidden"
+              >
+                <img
+                  src={post.thumbnailUrl ?? post.mediaUrl}
+                  alt={post.caption ? post.caption.slice(0, 100) : 'Instagram opslag'}
+                  className="h-full w-full object-cover transition-transform duration-500 hover:scale-105"
+                  loading="lazy"
+                />
+                <span className="absolute top-3 right-3 inline-flex items-center gap-1 rounded-full bg-black/70 px-3 py-1 text-xs text-white">
+                  <Images className="h-3.5 w-3.5" />
+                  {post.postType}
+                </span>
+              </a>
+
+              <div className="p-5 flex-1 flex flex-col gap-4">
+                <div>
+                  <div className="flex items-start justify-between gap-2">
+                    <h3 className="font-semibold text-brand-dark text-base">
+                      Opslag #{post.instagramId}
+                    </h3>
+                    <a
+                      href={post.permalink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-brand-primary hover:text-brand-dark flex items-center gap-1 text-sm"
+                    >
+                      Se opslag
+                      <ExternalLink className="h-4 w-4" />
+                    </a>
+                  </div>
+                  <p
+                    className="mt-2 text-sm text-gray-600 overflow-hidden text-ellipsis"
+                    style={{ display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: 3 }}
+                  >
+                    {post.caption ?? 'Ingen beskrivelse tilgængelig.'}
+                  </p>
+                </div>
+
+                <div className="flex items-center gap-4 text-sm text-gray-500">
+                  <span className="inline-flex items-center gap-1">
+                    <Heart className="h-4 w-4" />
+                    {post.likesCount}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <MessageCircle className="h-4 w-4" />
+                    {post.commentsCount}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <CalendarDays className="h-4 w-4" />
+                    {new Date(post.postedAt).toLocaleDateString('da-DK', {
+                      day: '2-digit',
+                      month: 'short',
+                      year: 'numeric'
+                    })}
+                  </span>
+                </div>
+
+                <div className="flex items-center justify-between gap-4">
+                  <Button
+                    variant={post.isFeatured ? 'secondary' : 'outline'}
+                    size="sm"
+                    onClick={() => handleToggleFeatured(post)}
+                    isLoading={isPending}
+                  >
+                    {post.isFeatured ? 'Fremhævet' : 'Fremhæv'}
+                  </Button>
+
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min={0}
+                      value={displayOrder}
+                      onChange={(event) => handleOrderChange(post.id, event.target.value)}
+                      className="w-20 rounded-lg border border-brown-200 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/20"
+                    />
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      onClick={() => handleSaveOrder(post)}
+                      disabled={!orderChanged}
+                      isLoading={isPending && orderChanged}
+                    >
+                      Gem
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </motion.div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white rounded-2xl shadow-soft border border-brown-100 p-6">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 rounded-xl bg-brand-primary/10 text-brand-primary flex items-center justify-center">
+              <Images className="h-6 w-6" />
+            </div>
+            <div>
+              <h1 className="text-xl font-serif font-bold text-brand-dark">
+                Instagram indhold på forsiden
+              </h1>
+              <p className="text-sm text-gray-600">
+                Vælg hvilke opslag der vises under overskriften på forsiden. Fremhæv op til {MAX_FEATURED_POSTS} opslag for den bedste præsentation.
+              </p>
+            </div>
+          </div>
+
+          <div className="text-sm text-right text-gray-600">
+            <p>
+              Fremhævede opslag: <span className="font-semibold text-brand-dark">{featuredCount}</span> / {MAX_FEATURED_POSTS}
+            </p>
+            {featuredCount > MAX_FEATURED_POSTS && (
+              <p className="mt-1 inline-flex items-center gap-1 text-red-600">
+                <AlertTriangle className="h-4 w-4" />
+                Visningen viser kun de første {MAX_FEATURED_POSTS} opslag efter sortering.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {renderContent()}
+    </div>
+  );
+};

--- a/src/frontend/src/pages/customer/LandingPage.tsx
+++ b/src/frontend/src/pages/customer/LandingPage.tsx
@@ -9,9 +9,14 @@ import {
   Users,
   Award,
   Instagram,
-  Calendar
+  Calendar,
+  Heart,
+  MessageCircle
 } from 'lucide-react';
 import { Button } from '@components/ui/Button';
+import { useGetInstagramPostsQuery } from '../../store/api';
+import type { InstagramPost } from '../../types';
+import { mapInstagramPostDto } from '../../utils/instagram';
 
 interface TestimonialProps {
   name: string;
@@ -91,6 +96,19 @@ const ServiceCard: React.FC<ServiceCardProps> = ({
 
 export const LandingPage: React.FC = () => {
   const navigate = useNavigate();
+  const {
+    data: instagramResponse,
+    isLoading: instagramLoading,
+    isError: instagramError
+  } = useGetInstagramPostsQuery({ limit: 9 });
+
+  const instagramPosts = React.useMemo<InstagramPost[]>(() => {
+    if (!instagramResponse?.data) {
+      return [];
+    }
+
+    return instagramResponse.data.map(mapInstagramPostDto).slice(0, 9);
+  }, [instagramResponse]);
 
   const testimonials = [
     {
@@ -157,12 +175,61 @@ export const LandingPage: React.FC = () => {
             >
               <h1 className="text-4xl md:text-5xl lg:text-6xl font-serif font-bold text-brand-dark mb-6 text-balance">
                 Professionel{' '}
-                <span className="text-gradient">Loc-pleje</span>{' '}
+                <span className="text-gradient">Loctician</span>{' '}
                 i København
               </h1>
+
+              <div className="mb-6">
+                {instagramLoading ? (
+                  <div className="grid grid-cols-3 gap-2">
+                    {Array.from({ length: 9 }).map((_, index) => (
+                      <div
+                        key={index}
+                        className="aspect-square rounded-md bg-white/60 animate-pulse"
+                      />
+                    ))}
+                  </div>
+                ) : instagramError ? (
+                  <div className="rounded-md border border-dashed border-brand-primary/40 bg-white/60 p-4 text-sm text-brand-dark/80">
+                    Kunne ikke hente Instagram-indhold i øjeblikket. Prøv igen senere.
+                  </div>
+                ) : instagramPosts.length ? (
+                  <div className="grid grid-cols-3 gap-2">
+                    {instagramPosts.map((post) => (
+                      <a
+                        key={post.id}
+                        href={post.permalink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group relative block aspect-square overflow-hidden rounded-md shadow-sm"
+                      >
+                        <img
+                          src={post.thumbnailUrl ?? post.mediaUrl}
+                          alt={post.caption ? post.caption.slice(0, 80) : 'Instagram opslag'}
+                          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                          loading="lazy"
+                        />
+                        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                        <div className="absolute bottom-0 left-0 right-0 p-2 text-white text-xs">
+                          <p
+                            className="leading-snug text-white/90 overflow-hidden text-ellipsis"
+                            style={{ display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: 2 }}
+                          >
+                            {post.caption ?? 'Se opslaget på Instagram'}
+                          </p>
+                        </div>
+                      </a>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="rounded-md border border-dashed border-brand-primary/40 bg-white/60 p-4 text-sm text-brand-dark/80">
+                    Ingen Instagram-opslag er fremhævet endnu.
+                  </div>
+                )}
+              </div>
+
               <p className="text-lg md:text-xl text-gray-600 mb-8 leading-relaxed">
-                Specialist i loc-vedligeholdelse, styling og pleje.
-                Book din tid hos Københavns mest betroede loctician.
+                Specialist i loc-vedligeholdelse, styling og pleje. Book din tid hos Københavns mest betryggende loctician.
               </p>
               <div className="flex flex-col sm:flex-row gap-4">
                 <Button
@@ -410,22 +477,71 @@ export const LandingPage: React.FC = () => {
             </Button>
           </motion.div>
 
-          {/* Instagram Grid Placeholder */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            className="grid grid-cols-2 md:grid-cols-4 gap-4"
-          >
-            {[1, 2, 3, 4].map((i) => (
-              <div
-                key={i}
-                className="aspect-square bg-brand-accent rounded-lg flex items-center justify-center"
-              >
-                <Instagram className="h-8 w-8 text-brand-primary" />
-              </div>
-            ))}
-          </motion.div>
+          {instagramLoading ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="aspect-square rounded-xl bg-brand-accent/50 animate-pulse"
+                />
+              ))}
+            </div>
+          ) : instagramError ? (
+            <div className="rounded-xl border border-dashed border-brand-primary/40 bg-brand-accent/40 p-6 text-brand-dark">
+              Kunne ikke hente Instagram-indhold i øjeblikket. Prøv igen senere.
+            </div>
+          ) : instagramPosts.length ? (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+            >
+              {instagramPosts.map((post, index) => (
+                <motion.a
+                  key={post.id}
+                  href={post.permalink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group relative aspect-square overflow-hidden rounded-xl shadow-soft"
+                  initial={{ opacity: 0, y: 20 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: index * 0.05 }}
+                >
+                  <img
+                    src={post.thumbnailUrl ?? post.mediaUrl}
+                    alt={post.caption ? post.caption.slice(0, 80) : 'Instagram opslag'}
+                    className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
+                    loading="lazy"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                  <div className="absolute bottom-0 left-0 right-0 p-4 text-white">
+                    <p
+                      className="text-sm font-medium text-white overflow-hidden text-ellipsis"
+                      style={{ display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: 2 }}
+                    >
+                      {post.caption ?? 'Se opslaget på Instagram'}
+                    </p>
+                    <div className="mt-3 flex items-center gap-4 text-xs text-white/80">
+                      <span className="flex items-center gap-1">
+                        <Heart className="h-4 w-4" />
+                        {post.likesCount}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <MessageCircle className="h-4 w-4" />
+                        {post.commentsCount}
+                      </span>
+                    </div>
+                  </div>
+                </motion.a>
+              ))}
+            </motion.div>
+          ) : (
+            <div className="rounded-xl border border-dashed border-brand-primary/40 bg-brand-accent/40 p-6 text-brand-dark">
+              Ingen Instagram-opslag er fremhævet endnu. Tjek igen senere for nye transformationer.
+            </div>
+          )}
         </div>
       </section>
 

--- a/src/frontend/src/store/api.ts
+++ b/src/frontend/src/store/api.ts
@@ -11,6 +11,8 @@ import type {
   ApiResponse,
   FilterOptions,
   BookingFormData,
+  InstagramPostDto,
+  InstagramPostUpdatePayload,
 } from '../types';
 
 // Define the API base URL
@@ -40,6 +42,7 @@ export const api = createApi({
     'Availability',
     'Analytics',
     'PageContent',
+    'InstagramPost',
   ],
   endpoints: (builder) => ({
     // Authentication endpoints
@@ -297,6 +300,57 @@ export const api = createApi({
         body: formData,
       }),
     }),
+
+    // Instagram endpoints
+    getInstagramPosts: builder.query<
+      ApiResponse<InstagramPostDto[]>,
+      { limit?: number } | void
+    >({
+      query: (params) => ({
+        url: '/instagram/posts',
+        params: {
+          limit: params?.limit ?? 9,
+        },
+      }),
+      providesTags: ['InstagramPost'],
+    }),
+
+    getInstagramPostsAdmin: builder.query<
+      ApiResponse<InstagramPostDto[]>,
+      { featuredOnly?: boolean } | void
+    >({
+      query: (params) => ({
+        url: '/instagram/posts/admin',
+        params: {
+          featured_only: params?.featuredOnly,
+        },
+      }),
+      providesTags: ['InstagramPost'],
+    }),
+
+    updateInstagramPost: builder.mutation<
+      ApiResponse<InstagramPostDto>,
+      { id: string; data: InstagramPostUpdatePayload }
+    >({
+      query: ({ id, data }) => {
+        const payload: Record<string, unknown> = {};
+
+        if (data.isFeatured !== undefined) {
+          payload.is_featured = data.isFeatured;
+        }
+
+        if (data.displayOrder !== undefined) {
+          payload.display_order = data.displayOrder;
+        }
+
+        return {
+          url: `/instagram/posts/${id}`,
+          method: 'PUT',
+          body: payload,
+        };
+      },
+      invalidatesTags: ['InstagramPost'],
+    }),
   }),
 });
 
@@ -327,4 +381,7 @@ export const {
   useGetPageQuery,
   useUpdatePageMutation,
   useUploadFileMutation,
+  useGetInstagramPostsQuery,
+  useGetInstagramPostsAdminQuery,
+  useUpdateInstagramPostMutation,
 } = api;

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -166,6 +166,46 @@ export interface ApiError {
   details?: Record<string, any>;
 }
 
+// Instagram content types
+export interface InstagramPostDto {
+  id: string;
+  instagram_id: string;
+  post_type: string;
+  caption?: string | null;
+  media_url: string;
+  thumbnail_url?: string | null;
+  permalink: string;
+  likes_count: number;
+  comments_count: number;
+  posted_at: string;
+  is_featured: boolean;
+  display_order: number;
+  synced_at?: string | null;
+  sync_error?: string | null;
+}
+
+export interface InstagramPost {
+  id: string;
+  instagramId: string;
+  postType: string;
+  caption?: string | null;
+  mediaUrl: string;
+  thumbnailUrl?: string | null;
+  permalink: string;
+  likesCount: number;
+  commentsCount: number;
+  postedAt: string;
+  isFeatured: boolean;
+  displayOrder: number;
+  syncedAt?: string | null;
+  syncError?: string | null;
+}
+
+export interface InstagramPostUpdatePayload {
+  isFeatured?: boolean;
+  displayOrder?: number;
+}
+
 // Analytics types
 export interface AnalyticsData {
   appointments: {

--- a/src/frontend/src/utils/instagram.ts
+++ b/src/frontend/src/utils/instagram.ts
@@ -1,0 +1,18 @@
+import type { InstagramPost, InstagramPostDto } from '../types';
+
+export const mapInstagramPostDto = (post: InstagramPostDto): InstagramPost => ({
+  id: post.id,
+  instagramId: post.instagram_id,
+  postType: post.post_type,
+  caption: post.caption ?? null,
+  mediaUrl: post.media_url,
+  thumbnailUrl: post.thumbnail_url ?? null,
+  permalink: post.permalink,
+  likesCount: post.likes_count,
+  commentsCount: post.comments_count,
+  postedAt: post.posted_at,
+  isFeatured: post.is_featured,
+  displayOrder: post.display_order,
+  syncedAt: post.synced_at ?? null,
+  syncError: post.sync_error ?? null,
+});


### PR DESCRIPTION
## Summary
- add FastAPI endpoints and schemas to serve featured Instagram posts and allow admin updates
- update the landing page hero copy and Instagram sections to render curated posts from the CMS
- add an admin content management page and navigation entry to manage the homepage Instagram feed

## Testing
- npm run lint *(fails: existing lint errors across the frontend codebase)*

------
https://chatgpt.com/codex/tasks/task_b_68daa284143c8330a157c92b9f5c76a3