### PR TITLE
Configure Brevo SMTP with STARTTLS

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -77,12 +77,14 @@ BACKEND_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,https://loctici
 # EMAIL CONFIGURATION
 # =============================================================================
 # SMTP settings for sending emails
-SMTP_HOST=smtp.gmail.com
+SMTP_HOST=smtp-relay.brevo.com
 SMTP_PORT=587
-SMTP_USER=your-email@gmail.com
-SMTP_PASSWORD=your-app-password
-SMTP_FROM=noreply@loctician.dk
+SMTP_USER=982547001@smtp-brevo.com
+SMTP_PASSWORD=JQaGXMjz8R9wWT3I
+SMTP_FROM=982547001@smtp-brevo.com
 SMTP_FROM_NAME="Loctician Booking System"
+SMTP_STARTTLS=true
+SMTP_SSL=false
 
 # =============================================================================
 # FILE UPLOAD CONFIGURATION

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -68,12 +68,14 @@ class Settings(BaseSettings):
         return self.BACKEND_CORS_ORIGINS
 
     # Email Configuration
-    SMTP_HOST: str = "smtp.gmail.com"
+    SMTP_HOST: str = "smtp-relay.brevo.com"
     SMTP_PORT: int = 587
     SMTP_USER: Optional[str] = None
     SMTP_PASSWORD: Optional[str] = None
     SMTP_FROM: Optional[str] = None
     SMTP_FROM_NAME: str = "Loctician Booking"
+    SMTP_STARTTLS: bool = True
+    SMTP_SSL: bool = False
 
     # File Upload
     MAX_FILE_SIZE_MB: int = 10

--- a/src/backend/app/services/email_service.py
+++ b/src/backend/app/services/email_service.py
@@ -109,6 +109,8 @@ class EmailSender:
         self.smtp_password = settings.SMTP_PASSWORD
         self.from_email = settings.SMTP_FROM
         self.from_name = settings.SMTP_FROM_NAME
+        self.smtp_starttls = getattr(settings, "SMTP_STARTTLS", True)
+        self.smtp_ssl = getattr(settings, "SMTP_SSL", False)
 
     async def send_email(
         self,
@@ -166,7 +168,8 @@ class EmailSender:
                 port=self.smtp_port,
                 username=self.smtp_user,
                 password=self.smtp_password,
-                use_tls=True,
+                start_tls=self.smtp_starttls,
+                use_tls=self.smtp_ssl,
             )
 
             logger.info(


### PR DESCRIPTION
## Summary
- switch default SMTP configuration to Brevo relay credentials
- add explicit STARTTLS/SSL flags so SMTP connections can use STARTTLS instead of implicit TLS
- update the email sender to honour the new TLS settings when sending mail

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68daf13830d883308b8ac9335d0f0bc6