### PR TITLE
Add CMS endpoints and public service catalog pages

### DIFF
--- a/src/backend/app/api/v1/endpoints/__init__.py
+++ b/src/backend/app/api/v1/endpoints/__init__.py
@@ -1,0 +1,33 @@
+"""Expose FastAPI endpoint modules for import convenience."""
+
+from . import (
+    auth,
+    bookings,
+    users,
+    availability,
+    calendar,
+    bookings_advanced,
+    users_management,
+    payments_mollie,
+    websocket_calendar,
+    monitoring,
+    instagram,
+    cms,
+    media,
+)
+
+__all__ = [
+    "auth",
+    "bookings",
+    "users",
+    "availability",
+    "calendar",
+    "bookings_advanced",
+    "users_management",
+    "payments_mollie",
+    "websocket_calendar",
+    "monitoring",
+    "instagram",
+    "cms",
+    "media",
+]

--- a/src/backend/app/api/v1/endpoints/cms.py
+++ b/src/backend/app/api/v1/endpoints/cms.py
@@ -1,0 +1,214 @@
+"""CMS endpoints for managing content pages."""
+from datetime import datetime
+from typing import List, Optional
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth.dependencies import get_current_admin
+from app.core.database import get_db
+from app.models.cms import CMSPage
+from app.models.enums import PageType
+from app.models.user import User
+from app.schemas.cms import (
+    CMSPageCreate,
+    CMSPageDetail,
+    CMSPageList,
+    CMSPagePublic,
+    CMSPageSummary,
+    CMSPageUpdate,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+def _published_filters(now: datetime) -> List:
+    """Generate SQLAlchemy filter clauses for published content."""
+
+    return [
+        CMSPage.is_published.is_(True),
+        or_(CMSPage.publish_at.is_(None), CMSPage.publish_at <= now),
+        or_(CMSPage.unpublish_at.is_(None), CMSPage.unpublish_at > now),
+    ]
+
+
+@router.get("/pages", response_model=CMSPageList)
+async def list_published_pages(
+    page_type: Optional[PageType] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    db: AsyncSession = Depends(get_db),
+) -> CMSPageList:
+    """Return published CMS pages with optional filtering by type."""
+
+    now = datetime.utcnow()
+    query = (
+        select(CMSPage)
+        .options(selectinload(CMSPage.hero_media))
+        .where(and_(*_published_filters(now)))
+        .order_by(CMSPage.publish_at.asc().nullsfirst(), CMSPage.title.asc())
+        .limit(limit)
+    )
+
+    if page_type:
+        query = query.where(CMSPage.page_type == page_type)
+
+    result = await db.execute(query)
+    pages = result.scalars().all()
+
+    return CMSPageList(
+        data=[CMSPageSummary.model_validate(page, from_attributes=True) for page in pages]
+    )
+
+
+@router.get("/pages/{slug}", response_model=CMSPageDetail)
+async def get_page_by_slug(slug: str, db: AsyncSession = Depends(get_db)) -> CMSPageDetail:
+    """Fetch a published page by slug."""
+
+    now = datetime.utcnow()
+    query = (
+        select(CMSPage)
+        .options(selectinload(CMSPage.hero_media))
+        .where(CMSPage.slug == slug)
+        .where(and_(*_published_filters(now)))
+    )
+
+    result = await db.execute(query)
+    page = result.scalar_one_or_none()
+
+    if not page:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Page not found",
+        )
+
+    return CMSPageDetail(data=CMSPagePublic.model_validate(page, from_attributes=True))
+
+
+@router.get("/pages/admin", response_model=CMSPageList)
+async def list_pages_admin(
+    page_type: Optional[PageType] = Query(default=None),
+    include_unpublished: bool = Query(default=True),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> CMSPageList:
+    """List pages for CMS administrators."""
+
+    query = select(CMSPage).options(selectinload(CMSPage.hero_media)).order_by(
+        CMSPage.updated_at.desc()
+    )
+
+    if page_type:
+        query = query.where(CMSPage.page_type == page_type)
+
+    if not include_unpublished:
+        query = query.where(and_(*_published_filters(datetime.utcnow())))
+
+    result = await db.execute(query)
+    pages = result.scalars().all()
+
+    return CMSPageList(
+        data=[CMSPageSummary.model_validate(page, from_attributes=True) for page in pages]
+    )
+
+
+@router.post("/pages", response_model=CMSPageDetail, status_code=status.HTTP_201_CREATED)
+async def create_page(
+    payload: CMSPageCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_admin),
+) -> CMSPageDetail:
+    """Create a new CMS page."""
+
+    page = CMSPage(
+        title=payload.title,
+        slug=payload.slug,
+        content=payload.content,
+        excerpt=payload.excerpt,
+        page_type=payload.page_type,
+        meta_title=payload.meta_title,
+        meta_description=payload.meta_description,
+        meta_keywords=payload.meta_keywords,
+        gdpr_version=payload.gdpr_version,
+        is_published=payload.is_published,
+        publish_at=payload.publish_at,
+        unpublish_at=payload.unpublish_at,
+        hero_media_id=payload.hero_media_id,
+        author_id=current_user.id,
+    )
+
+    if page.is_published and page.publish_at is None:
+        page.published_at = datetime.utcnow()
+
+    db.add(page)
+
+    try:
+        await db.commit()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        await db.rollback()
+        logger.error("Create CMS page error", error=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unable to create page",
+        ) from exc
+
+    await db.refresh(page)
+
+    return CMSPageDetail(data=CMSPagePublic.model_validate(page, from_attributes=True))
+
+
+@router.put("/pages/{page_id}", response_model=CMSPageDetail)
+async def update_page(
+    page_id: str,
+    payload: CMSPageUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_admin),
+) -> CMSPageDetail:
+    """Update an existing CMS page."""
+
+    result = await db.execute(
+        select(CMSPage).options(selectinload(CMSPage.hero_media)).where(CMSPage.id == page_id)
+    )
+    page = result.scalar_one_or_none()
+
+    if not page:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Page not found")
+
+    updates = payload.model_dump(exclude_unset=True)
+    for field, value in updates.items():
+        setattr(page, field, value)
+
+    if page.is_published and page.published_at is None:
+        page.published_at = datetime.utcnow()
+
+    page.updated_at = datetime.utcnow()
+    page.author_id = page.author_id or current_user.id
+
+    await db.commit()
+    await db.refresh(page)
+
+    return CMSPageDetail(data=CMSPagePublic.model_validate(page, from_attributes=True))
+
+
+@router.delete("/pages/{page_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_page(
+    page_id: str,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> None:
+    """Remove a CMS page."""
+
+    result = await db.execute(select(CMSPage).where(CMSPage.id == page_id))
+    page = result.scalar_one_or_none()
+
+    if not page:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Page not found")
+
+    await db.delete(page)
+    await db.commit()
+
+    return None

--- a/src/backend/app/api/v1/endpoints/media.py
+++ b/src/backend/app/api/v1/endpoints/media.py
@@ -1,0 +1,138 @@
+"""Media library endpoints."""
+from typing import Optional
+
+import structlog
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth.dependencies import get_current_admin
+from app.core.database import get_db
+from app.models.media import MediaFile
+from app.models.user import User
+from app.schemas.media import (
+    MediaFileAdmin,
+    MediaFileList,
+    MediaFilePublic,
+    MediaFilePublicList,
+    MediaFileUpdate,
+)
+from app.services.media_service import media_service
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/featured", response_model=MediaFilePublicList)
+async def list_featured_media(
+    limit: int = 12,
+    db: AsyncSession = Depends(get_db),
+) -> MediaFilePublicList:
+    """Return featured media for public display."""
+
+    result = await db.execute(
+        select(MediaFile)
+        .where(MediaFile.is_published.is_(True), MediaFile.is_featured.is_(True))
+        .order_by(MediaFile.display_order.asc(), MediaFile.published_at.desc())
+        .limit(limit)
+    )
+    media_items = result.scalars().all()
+
+    return MediaFilePublicList(
+        data=[MediaFilePublic.model_validate(item, from_attributes=True) for item in media_items]
+    )
+
+
+@router.get("/", response_model=MediaFileList)
+async def list_media_admin(
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> MediaFileList:
+    """List media for administrators."""
+
+    result = await db.execute(
+        select(MediaFile)
+        .options(selectinload(MediaFile.uploader))
+        .order_by(MediaFile.uploaded_at.desc())
+    )
+    media_items = result.scalars().all()
+
+    return MediaFileList(
+        data=[MediaFileAdmin.model_validate(item, from_attributes=True) for item in media_items]
+    )
+
+
+@router.post("/upload", response_model=MediaFileAdmin, status_code=status.HTTP_201_CREATED)
+async def upload_media(
+    file: UploadFile = File(...),
+    alt_text: Optional[str] = None,
+    caption: Optional[str] = None,
+    is_featured: bool = False,
+    display_order: int = 0,
+    is_published: bool = True,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_admin),
+) -> MediaFileAdmin:
+    """Upload a new media file."""
+
+    media = await media_service.save_upload(
+        db,
+        file,
+        user_id=current_user.id,
+        alt_text=alt_text,
+        caption=caption,
+        is_featured=is_featured,
+        display_order=display_order,
+        is_published=is_published,
+    )
+
+    return MediaFileAdmin.model_validate(media, from_attributes=True)
+
+
+@router.put("/{media_id}", response_model=MediaFileAdmin)
+async def update_media(
+    media_id: str,
+    payload: MediaFileUpdate,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> MediaFileAdmin:
+    """Update metadata for a media file."""
+
+    result = await db.execute(select(MediaFile).where(MediaFile.id == media_id))
+    media = result.scalar_one_or_none()
+
+    if not media:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media not found")
+
+    media = await media_service.update_media(
+        db,
+        media,
+        alt_text=payload.alt_text,
+        caption=payload.caption,
+        is_featured=payload.is_featured,
+        display_order=payload.display_order,
+        is_published=payload.is_published,
+    )
+
+    return MediaFileAdmin.model_validate(media, from_attributes=True)
+
+
+@router.delete("/{media_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_media(
+    media_id: str,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_admin),
+) -> None:
+    """Delete a media file."""
+
+    result = await db.execute(select(MediaFile).where(MediaFile.id == media_id))
+    media = result.scalar_one_or_none()
+
+    if not media:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media not found")
+
+    await media_service.delete_media(db, media)
+
+    return None

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -78,7 +78,18 @@ class Settings(BaseSettings):
     # File Upload
     MAX_FILE_SIZE_MB: int = 10
     UPLOAD_PATH: str = "./uploads"
-    ALLOWED_EXTENSIONS: List[str] = ["jpg", "jpeg", "png", "gif", "pdf"]
+    ALLOWED_EXTENSIONS: List[str] = [
+        "jpg",
+        "jpeg",
+        "png",
+        "gif",
+        "webp",
+        "pdf",
+        "mp4",
+        "mov",
+        "webm",
+        "mkv",
+    ]
 
     # Rate Limiting
     RATE_LIMIT_PER_MINUTE: int = 60

--- a/src/backend/app/models/cms.py
+++ b/src/backend/app/models/cms.py
@@ -23,6 +23,7 @@ class CMSPage(Base, BaseModel):
     content: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     excerpt: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     page_type: Mapped[PageType] = mapped_column(default=PageType.PAGE, nullable=False)
+    gdpr_version: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
 
     # SEO
     meta_title: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
@@ -50,9 +51,15 @@ class CMSPage(Base, BaseModel):
         ForeignKey("users.id"),
         nullable=True,
     )
+    hero_media_id: Mapped[Optional[str]] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("media_files.id"),
+        nullable=True,
+    )
 
     # Relationships
     author: Mapped[Optional["User"]] = relationship("User")
+    hero_media: Mapped[Optional["MediaFile"]] = relationship("MediaFile")
 
     @property
     def is_currently_published(self) -> bool:

--- a/src/backend/app/models/media.py
+++ b/src/backend/app/models/media.py
@@ -1,15 +1,19 @@
-"""
-Media file model.
-"""
-from datetime import datetime
+"""Media file model."""
+from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
 from app.models.mixins import UUIDMixin
+
+
+def utcnow() -> datetime:
+    """Return an aware UTC timestamp for default fields."""
+
+    return datetime.now(timezone.utc)
 
 
 class MediaFile(Base, UUIDMixin):
@@ -26,6 +30,12 @@ class MediaFile(Base, UUIDMixin):
     height: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     alt_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     caption: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    is_featured: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    display_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    is_published: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    published_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=utcnow
+    )
 
     uploaded_by: Mapped[Optional[str]] = mapped_column(
         UUID(as_uuid=False),
@@ -33,7 +43,7 @@ class MediaFile(Base, UUIDMixin):
         nullable=True,
     )
     uploaded_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
+        DateTime(timezone=True), nullable=False, default=utcnow
     )
 
     # Relationships
@@ -48,6 +58,11 @@ class MediaFile(Base, UUIDMixin):
     def file_size_mb(self) -> float:
         """Get file size in megabytes."""
         return round(self.file_size / (1024 * 1024), 2)
+
+    @property
+    def public_url(self) -> str:
+        """Public URL served by FastAPI static mount."""
+        return f"/media/{self.file_path}"
 
     def __repr__(self) -> str:
         return f"<MediaFile(id={self.id}, filename={self.filename})>"

--- a/src/backend/app/schemas/cms.py
+++ b/src/backend/app/schemas/cms.py
@@ -1,0 +1,92 @@
+"""Pydantic schemas for CMS pages."""
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.models.enums import PageType
+from app.schemas.media import MediaFilePublic
+
+
+class CMSPageBase(BaseModel):
+    """Shared CMS page fields."""
+
+    title: str
+    slug: str
+    excerpt: Optional[str] = None
+    page_type: PageType = PageType.PAGE
+    meta_title: Optional[str] = None
+    meta_description: Optional[str] = None
+    meta_keywords: Optional[List[str]] = None
+    gdpr_version: Optional[str] = Field(default=None, max_length=20)
+
+
+class CMSPageCreate(CMSPageBase):
+    """Schema for creating a CMS page."""
+
+    content: Optional[str] = None
+    is_published: bool = False
+    publish_at: Optional[datetime] = None
+    unpublish_at: Optional[datetime] = None
+    hero_media_id: Optional[str] = None
+
+
+class CMSPageUpdate(BaseModel):
+    """Schema for updating a CMS page."""
+
+    title: Optional[str] = None
+    slug: Optional[str] = None
+    content: Optional[str] = None
+    excerpt: Optional[str] = None
+    page_type: Optional[PageType] = None
+    meta_title: Optional[str] = None
+    meta_description: Optional[str] = None
+    meta_keywords: Optional[List[str]] = None
+    gdpr_version: Optional[str] = Field(default=None, max_length=20)
+    is_published: Optional[bool] = None
+    publish_at: Optional[datetime] = None
+    unpublish_at: Optional[datetime] = None
+    hero_media_id: Optional[str] = None
+
+
+class CMSPagePublic(CMSPageBase):
+    """Public CMS page payload."""
+
+    id: str
+    content: Optional[str] = None
+    is_published: bool
+    published_at: Optional[datetime] = None
+    publish_at: Optional[datetime] = None
+    unpublish_at: Optional[datetime] = None
+    updated_at: datetime
+    hero_media: Optional[MediaFilePublic] = None
+
+    class Config:
+        from_attributes = True
+
+
+class CMSPageSummary(BaseModel):
+    """Slimmed-down page summary for listings."""
+
+    id: str
+    title: str
+    slug: str
+    page_type: PageType
+    is_published: bool
+    published_at: Optional[datetime] = None
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class CMSPageList(BaseModel):
+    """Wrapper for CMS page list responses."""
+
+    data: List[CMSPageSummary]
+
+
+class CMSPageDetail(BaseModel):
+    """Wrapper for page detail responses."""
+
+    data: CMSPagePublic

--- a/src/backend/app/schemas/media.py
+++ b/src/backend/app/schemas/media.py
@@ -1,0 +1,66 @@
+"""Pydantic schemas for media library files."""
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class MediaFileBase(BaseModel):
+    """Base media file representation."""
+
+    id: str
+    original_filename: str
+    mime_type: str
+    file_size: int
+    alt_text: Optional[str] = None
+    caption: Optional[str] = None
+    is_featured: bool = False
+    display_order: int = 0
+    is_published: bool = True
+    published_at: datetime
+    url: str = Field(..., alias="public_url")
+
+    class Config:
+        from_attributes = True
+        populate_by_name = True
+
+
+class MediaFilePublic(MediaFileBase):
+    """Media file payload exposed to the public frontend."""
+
+    pass
+
+
+class MediaFileAdmin(MediaFileBase):
+    """Media file payload for CMS administrators."""
+
+    filename: str
+    file_path: str
+    uploaded_by: Optional[str] = None
+    uploaded_at: datetime
+    file_size_mb: float = Field(..., alias="file_size_mb")
+
+    class Config(MediaFileBase.Config):
+        pass
+
+
+class MediaFileUpdate(BaseModel):
+    """Payload for updating media metadata."""
+
+    alt_text: Optional[str] = None
+    caption: Optional[str] = None
+    is_featured: Optional[bool] = None
+    display_order: Optional[int] = Field(default=None, ge=0)
+    is_published: Optional[bool] = None
+
+
+class MediaFileList(BaseModel):
+    """Wrapper schema for list responses."""
+
+    data: List[MediaFileAdmin]
+
+
+class MediaFilePublicList(BaseModel):
+    """Wrapper schema for public list responses."""
+
+    data: List[MediaFilePublic]

--- a/src/backend/app/services/media_service.py
+++ b/src/backend/app/services/media_service.py
@@ -1,0 +1,137 @@
+"""Media library service helpers."""
+from __future__ import annotations
+
+import mimetypes
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from uuid import uuid4
+
+from fastapi import HTTPException, UploadFile, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.media import MediaFile
+
+
+class MediaService:
+    """Service responsible for handling media uploads and metadata updates."""
+
+    def __init__(self) -> None:
+        self.base_path = Path(settings.UPLOAD_PATH).resolve()
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.allowed_extensions = {ext.lower() for ext in settings.ALLOWED_EXTENSIONS}
+        self.max_file_size = settings.MAX_FILE_SIZE_MB * 1024 * 1024
+
+    async def save_upload(
+        self,
+        db: AsyncSession,
+        upload: UploadFile,
+        *,
+        user_id: Optional[str],
+        alt_text: Optional[str] = None,
+        caption: Optional[str] = None,
+        is_featured: bool = False,
+        display_order: int = 0,
+        is_published: bool = True,
+    ) -> MediaFile:
+        """Persist an uploaded file and create the corresponding database row."""
+
+        original_filename = upload.filename or "untitled"
+        extension = Path(original_filename).suffix.lower().lstrip(".")
+
+        if not extension and upload.content_type:
+            guessed = mimetypes.guess_extension(upload.content_type)
+            if guessed:
+                extension = guessed.lstrip(".")
+
+        if not extension or extension not in self.allowed_extensions:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="File type is not allowed",
+            )
+
+        contents = await upload.read()
+        if not contents:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Uploaded file was empty",
+            )
+
+        if len(contents) > self.max_file_size:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"File exceeds the maximum size of {settings.MAX_FILE_SIZE_MB} MB",
+            )
+
+        unique_name = f"{uuid4().hex}.{extension}"
+        destination = self.base_path / unique_name
+
+        destination.write_bytes(contents)
+
+        mime_type = upload.content_type or mimetypes.guess_type(original_filename)[0] or "application/octet-stream"
+
+        media = MediaFile(
+            filename=unique_name,
+            original_filename=original_filename,
+            file_path=unique_name,
+            file_size=len(contents),
+            mime_type=mime_type,
+            alt_text=alt_text,
+            caption=caption,
+            uploaded_by=user_id,
+            is_featured=is_featured,
+            display_order=display_order,
+            is_published=is_published,
+            published_at=datetime.now(timezone.utc),
+            uploaded_at=datetime.now(timezone.utc),
+        )
+
+        db.add(media)
+        await db.commit()
+        await db.refresh(media)
+
+        return media
+
+    async def update_media(
+        self,
+        db: AsyncSession,
+        media: MediaFile,
+        *,
+        alt_text: Optional[str] = None,
+        caption: Optional[str] = None,
+        is_featured: Optional[bool] = None,
+        display_order: Optional[int] = None,
+        is_published: Optional[bool] = None,
+    ) -> MediaFile:
+        """Apply updates to an existing media file."""
+
+        if alt_text is not None:
+            media.alt_text = alt_text
+        if caption is not None:
+            media.caption = caption
+        if is_featured is not None:
+            media.is_featured = is_featured
+        if display_order is not None:
+            media.display_order = display_order
+        if is_published is not None:
+            media.is_published = is_published
+            if is_published and media.published_at is None:
+                media.published_at = datetime.now(timezone.utc)
+
+        await db.commit()
+        await db.refresh(media)
+        return media
+
+    async def delete_media(self, db: AsyncSession, media: MediaFile) -> None:
+        """Delete a media file from disk and the database."""
+
+        storage_path = self.base_path / media.file_path
+        if storage_path.exists():
+            storage_path.unlink()
+
+        await db.delete(media)
+        await db.commit()
+
+
+media_service = MediaService()

--- a/src/db/sample_data.sql
+++ b/src/db/sample_data.sql
@@ -424,9 +424,63 @@ INSERT INTO cms_pages (title, slug, content, page_type, is_published, published_
     <li>Undgå styling produkter dagen før</li>
     <li>Medbringe egen hovedbeklædning hvis ønsket</li>
   </ul>',
+'page', true, NOW(),
+'Booking Politik - Regler og Betingelser',
+'Læs vores booking politik, aflysningsregler og betalingsbetingelser før din aftale.');
+
+INSERT INTO cms_pages (
+  title,
+  slug,
+  content,
+  page_type,
+  is_published,
+  published_at,
+  meta_title,
+  meta_description,
+  gdpr_version
+) VALUES
+('Vilkår og GDPR', 'terms-of-service',
+ '<h1>Vilkår, betingelser og GDPR</h1>
+
+  <p>Vi behandler dine persondata med størst mulig omhu og i henhold til EU''s databeskyttelsesforordning (GDPR). Ved at bruge vores services accepterer du følgende vilkår:</p>
+
+  <h2>Indsamling af data</h2>
+  <p>Vi indsamler kun de oplysninger, der er nødvendige for at kunne tilbyde og forbedre vores ydelser, herunder kontaktoplysninger, bookinghistorik og eventuelle noter du deler med os.</p>
+
+  <h2>Dine rettigheder</h2>
+  <ul>
+    <li>Ret til indsigt i de oplysninger vi har registreret om dig</li>
+    <li>Ret til berigtigelse af forkerte eller ufuldstændige oplysninger</li>
+    <li>Ret til sletning (''retten til at blive glemt'') hvor lovgivningen tillader det</li>
+    <li>Ret til dataportabilitet og begrænsning af behandling</li>
+  </ul>
+
+  <h2>Samtykke</h2>
+  <p>Vi baserer behandlingen af dine data på et eksplicit samtykke, som du til enhver tid kan trække tilbage ved at kontakte os på info@justloccit.dk.</p>
+
+  <h2>Opbevaring</h2>
+  <p>Dine data opbevares sikkert og slettes løbende, når de ikke længere er nødvendige. Fakturadata opbevares i henhold til gældende regnskabslovgivning.</p>',
  'page', true, NOW(),
- 'Booking Politik - Regler og Betingelser',
- 'Læs vores booking politik, aflysningsregler og betalingsbetingelser før din aftale.');
+ 'Vilkår og GDPR - Just Locc It',
+ 'Læs om hvordan vi indsamler, bruger og beskytter dine persondata samt hvilke rettigheder du har som kunde.',
+ '1.0.0');
+
+INSERT INTO media_files (
+    filename,
+    original_filename,
+    file_path,
+    file_size,
+    mime_type,
+    alt_text,
+    caption,
+    is_featured,
+    display_order,
+    is_published,
+    published_at
+) VALUES
+('sample-gallery-1.jpg', 'gallery-1.jpg', 'sample-gallery-1.jpg', 245678, 'image/jpeg', 'Før og efter starter locs', 'Før/efter starter locs med naturlig finish', true, 1, true, NOW()),
+('sample-gallery-2.jpg', 'gallery-2.jpg', 'sample-gallery-2.jpg', 312456, 'image/jpeg', 'Vedligeholdelse af modne locs', 'Vedligeholdelse og styling af modne locs', true, 2, true, NOW()),
+('sample-gallery-video.mp4', 'gallery-video.mp4', 'sample-gallery-video.mp4', 1048576, 'video/mp4', 'Kort video fra salonen', 'En kort præsentation fra vores salon', false, 3, true, NOW());
 
 -- =====================================================
 -- SAMPLE INSTAGRAM POSTS

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -385,6 +385,7 @@ CREATE TABLE cms_pages (
     content TEXT,
     excerpt TEXT,
     page_type page_type NOT NULL DEFAULT 'page',
+    gdpr_version VARCHAR(20),
 
     -- SEO
     meta_title VARCHAR(200),
@@ -401,6 +402,7 @@ CREATE TABLE cms_pages (
 
     -- Authoring
     author_id UUID REFERENCES users(id),
+    hero_media_id UUID REFERENCES media_files(id),
 
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -418,10 +420,17 @@ CREATE TABLE media_files (
     height INTEGER,
     alt_text TEXT,
     caption TEXT,
+    is_featured BOOLEAN DEFAULT FALSE,
+    display_order INTEGER DEFAULT 0,
+    is_published BOOLEAN DEFAULT TRUE,
+    published_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
 
     uploaded_by UUID REFERENCES users(id),
     uploaded_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
+
+CREATE INDEX idx_media_files_featured ON media_files (is_featured, display_order)
+WHERE is_featured = TRUE AND is_published = TRUE;
 
 -- =====================================================
 -- INSTAGRAM INTEGRATION

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -24,6 +24,10 @@ import { LoadingSpinner } from './components/ui/LoadingSpinner';
 import { LandingPage } from './pages/customer/LandingPage';
 import { LoginPage } from './pages/auth/LoginPage';
 import { RegisterPage } from './pages/auth/RegisterPage';
+import { ForgotPasswordPage } from './pages/auth/ForgotPasswordPage';
+import { ResetPasswordPage } from './pages/auth/ResetPasswordPage';
+import { TermsPage } from './pages/legal/TermsPage';
+import { ServicesCatalogPage } from './pages/customer/ServicesCatalogPage';
 
 // Customer pages - lazy load
 const BookingPage = lazy(() => import('./pages/customer/BookingPage').then(m => ({ default: m.BookingPage })));
@@ -186,6 +190,11 @@ const AppContent: React.FC = () => {
           <Route path="/" element={<LandingPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
+          <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+          <Route path="/reset-password" element={<ResetPasswordPage />} />
+          <Route path="/terms" element={<TermsPage />} />
+          <Route path="/tjenester" element={<ServicesCatalogPage />} />
+          <Route path="/services/catalog" element={<ServicesCatalogPage />} />
 
           {/* Customer Routes - Lazy loaded */}
           <Route

--- a/src/frontend/src/components/layout/Header.tsx
+++ b/src/frontend/src/components/layout/Header.tsx
@@ -12,6 +12,7 @@ import {
   Phone,
   Mail
 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@components/ui/Button';
 import clsx from 'clsx';
 
@@ -32,6 +33,7 @@ export const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const userMenuRef = useRef<HTMLDivElement>(null);
+  const { t } = useTranslation();
 
   // Close menus when clicking outside
   useEffect(() => {
@@ -50,11 +52,14 @@ export const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
     setIsMobileMenuOpen(false);
   }, [location.pathname]);
 
-  const navigationItems = [
-    { href: '/', label: 'Hjem', labelEn: 'Home' },
-    { href: '/services', label: 'Tjenester', labelEn: 'Services' },
-    { href: '/contact', label: 'Kontakt', labelEn: 'Contact' },
-  ];
+  const navigationItems = React.useMemo<Array<{ href: string; labelKey: string }>>(
+    () => [
+      { href: '/', labelKey: 'navigation.home' },
+      { href: '/tjenester', labelKey: 'navigation.services' },
+      { href: '/contact', labelKey: 'navigation.contact' },
+    ],
+    []
+  );
 
   const userMenuItems = [
     {
@@ -90,7 +95,7 @@ export const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
           <Link
             to="/"
             className="flex items-center space-x-2"
-            aria-label="Just Locc It - Hjem"
+            aria-label={`Just Locc It - ${t('navigation.home')}`}
           >
             <div className="w-10 h-10 bg-brand-primary rounded-full flex items-center justify-center">
               <span className="text-white font-bold text-lg">JLI</span>
@@ -108,10 +113,14 @@ export const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
                 to={item.href}
                 className={clsx(
                   'text-brand-dark hover:text-brand-primary transition-colors duration-200 font-medium',
-                  location.pathname === item.href && 'text-brand-primary'
+                  (item.href === '/' && location.pathname === '/') ||
+                    (item.href !== '/' && location.pathname.startsWith(item.href)) ||
+                    (item.href === '/tjenester' && location.pathname.startsWith('/services/catalog'))
+                    ? 'text-brand-primary'
+                    : undefined
                 )}
               >
-                {item.label}
+                {t(item.labelKey)}
               </Link>
             ))}
           </nav>
@@ -144,7 +153,7 @@ export const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
               size="sm"
               className="hidden sm:inline-flex"
             >
-              Book Nu
+              {t('navigation.booking')}
             </Button>
 
             {/* User Menu or Auth Buttons */}
@@ -256,7 +265,7 @@ export const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
                       location.pathname === item.href && 'bg-brand-accent text-brand-primary'
                     )}
                   >
-                    {item.label}
+                    {t(item.labelKey)}
                   </Link>
                 ))}
               </nav>
@@ -264,7 +273,7 @@ export const Header: React.FC<HeaderProps> = ({ user, onLogout }) => {
               {/* Mobile Book Button */}
               <div className="px-4">
                 <Button onClick={handleBookNow} fullWidth>
-                  Book Nu
+                  {t('navigation.booking')}
                 </Button>
               </div>
 

--- a/src/frontend/src/i18n/locales/da.json
+++ b/src/frontend/src/i18n/locales/da.json
@@ -66,6 +66,25 @@
       "hasAccount": "Har du allerede en konto?",
       "signIn": "Log ind her"
     },
+    "forgotPassword": {
+      "title": "Glemt adgangskode",
+      "subtitle": "Indtast din e-mail for at nulstille din adgangskode.",
+      "submit": "Send nulstillingslink",
+      "successMessage": "Hvis e-mailen findes i vores system, er der sendt et nulstillingslink.",
+      "backToLogin": "Tilbage til login",
+      "error": "Vi kunne ikke sende nulstillingslinket. Prøv venligst igen."
+    },
+    "resetPassword": {
+      "title": "Nulstil adgangskode",
+      "subtitle": "Vælg en ny sikker adgangskode.",
+      "newPassword": "Ny adgangskode",
+      "confirmPassword": "Bekræft adgangskode",
+      "submit": "Opdater adgangskode",
+      "successMessage": "Din adgangskode er opdateret. Du videresendes til login.",
+      "backToLogin": "Tilbage til login",
+      "error": "Vi kunne ikke nulstille adgangskoden. Prøv igen.",
+      "invalidToken": "Nulstillingslinket er ugyldigt eller udløbet."
+    },
     "errors": {
       "invalidCredentials": "Ugyldig e-mail eller adgangskode",
       "emailExists": "E-mail er allerede i brug",
@@ -127,11 +146,41 @@
     "from": "Fra",
     "bookNow": "Book nu",
     "learnMore": "Læs mere",
+    "heroBadge": "Eksperter i locs & naturligt hår",
+    "heroTitle": "Vælg din næste behandling",
+    "heroSubtitle": "Oplev håndlavede services, specialiseret vejledning og kærlig pleje til dit naturlige hår.",
+    "allServices": "Alle services",
+    "emptyState": "Ingen services at vise i denne kategori endnu.",
+    "requirements": "Sådan forbereder du dig",
+    "aftercare": "Efterbehandling",
+    "bookCta": "Book tid",
     "categories": {
       "maintenance": "Vedligeholdelse",
       "styling": "Styling",
       "treatment": "Behandling",
       "consultation": "Konsultation"
+    },
+    "media": {
+      "title": "Galleri & inspiration",
+      "subtitle": "Se udvalgte billeder og videoer fra de seneste behandlinger.",
+      "videoBadge": "Video"
+    }
+  },
+  "legal": {
+    "terms": {
+      "title": "Vilkår, betingelser & GDPR",
+      "subtitle": "Sådan behandler vi dine oplysninger og samtykker.",
+      "version": "Version {{version}}",
+      "updated": "Opdateret {{date}}",
+      "error": "Kunne ikke indlæse siden. Viser seneste kendte information.",
+      "fallback": {
+        "processingTitle": "Behandling af persondata",
+        "processingText": "Vi indsamler kun de oplysninger, der er nødvendige for at levere vores tjenester. Data opbevares sikkert og kun så længe det er nødvendigt i henhold til gældende lovgivning.",
+        "rightsTitle": "Samtykke og rettigheder",
+        "rightsText": "Du kan til enhver tid trække dit samtykke tilbage og anmode om indsigt, rettelse eller sletning af dine data. Kontakt os via kundeservice for at udøve dine rettigheder.",
+        "cookiesTitle": "Cookies",
+        "cookiesText": "Vi anvender kun tekniske cookies, der er nødvendige for at sikre en stabil og sikker bookingoplevelse. Ingen sporingscookies anvendes uden udtrykkeligt samtykke."
+      }
     }
   },
   "calendar": {
@@ -288,6 +337,14 @@
     "subject": "Emne",
     "message": "Besked",
     "messageSent": "Besked sendt"
+  },
+  "landing": {
+    "media": {
+      "title": "Galleri & inspiration",
+      "subtitle": "Udforsk både vores Instagram-univers og eksklusive uploads direkte fra salonen.",
+      "error": "Vi kunne ikke hente galleriet lige nu. Prøv igen senere.",
+      "empty": "Vi har endnu ikke fremhævet uploadede medier. Kig snart forbi igen."
+    }
   },
   "footer": {
     "rights": "Alle rettigheder forbeholdes",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -72,6 +72,25 @@
       "hasAccount": "Already have an account?",
       "signIn": "Sign in here"
     },
+    "forgotPassword": {
+      "title": "Forgot password",
+      "subtitle": "Enter your email to receive a reset link.",
+      "submit": "Send reset link",
+      "successMessage": "If the email exists in our system, a reset link has been sent.",
+      "backToLogin": "Back to login",
+      "error": "We could not send the reset link. Please try again."
+    },
+    "resetPassword": {
+      "title": "Reset password",
+      "subtitle": "Choose a new secure password.",
+      "newPassword": "New password",
+      "confirmPassword": "Confirm password",
+      "submit": "Update password",
+      "successMessage": "Your password has been updated. Redirecting to login...",
+      "backToLogin": "Back to login",
+      "error": "We could not reset the password. Please try again.",
+      "invalidToken": "The reset link is invalid or has expired."
+    },
     "errors": {
       "invalidCredentials": "Invalid email or password",
       "emailExists": "Email is already in use",
@@ -133,11 +152,41 @@
     "from": "From",
     "bookNow": "Book Now",
     "learnMore": "Learn More",
+    "heroBadge": "Experts in locs & natural hair",
+    "heroTitle": "Choose your next treatment",
+    "heroSubtitle": "Discover handcrafted services, tailored guidance and caring maintenance for your natural hair.",
+    "allServices": "All services",
+    "emptyState": "No services to display in this category yet.",
+    "requirements": "How to prepare",
+    "aftercare": "Aftercare",
+    "bookCta": "Book appointment",
     "categories": {
       "maintenance": "Maintenance",
       "styling": "Styling",
       "treatment": "Treatment",
       "consultation": "Consultation"
+    },
+    "media": {
+      "title": "Gallery & inspiration",
+      "subtitle": "Browse highlighted photos and videos from recent appointments.",
+      "videoBadge": "Video"
+    }
+  },
+  "legal": {
+    "terms": {
+      "title": "Terms, conditions & GDPR",
+      "subtitle": "How we handle your information and consents.",
+      "version": "Version {{version}}",
+      "updated": "Updated {{date}}",
+      "error": "Unable to load the page. Showing the last known information.",
+      "fallback": {
+        "processingTitle": "Processing of personal data",
+        "processingText": "We only collect the information necessary to deliver our services. Data is stored securely and only as long as required by applicable legislation.",
+        "rightsTitle": "Consent and rights",
+        "rightsText": "You can withdraw your consent at any time and request access, correction or deletion of your data. Contact us via customer service to exercise your rights.",
+        "cookiesTitle": "Cookies",
+        "cookiesText": "We use only technical cookies required to ensure a stable and secure booking experience. No tracking cookies are used without explicit consent."
+      }
     }
   },
   "calendar": {
@@ -294,6 +343,14 @@
     "subject": "Subject",
     "message": "Message",
     "messageSent": "Message sent"
+  },
+  "landing": {
+    "media": {
+      "title": "Gallery & inspiration",
+      "subtitle": "Explore our Instagram universe alongside exclusive uploads straight from the salon.",
+      "error": "We couldn’t load the gallery right now. Please try again later.",
+      "empty": "We haven’t featured any uploaded media yet. Check back soon."
+    }
   },
   "footer": {
     "rights": "All rights reserved",

--- a/src/frontend/src/pages/auth/ForgotPasswordPage.tsx
+++ b/src/frontend/src/pages/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import { Mail } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { Button, Card, CardContent, Input } from '../../components/ui';
+import { useRequestPasswordResetMutation } from '../../store/api';
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email('Indtast en gyldig e-mail'),
+});
+
+type ForgotPasswordForm = z.infer<typeof forgotPasswordSchema>;
+
+export const ForgotPasswordPage: React.FC = () => {
+  const { t } = useTranslation();
+  const [requestReset, { isLoading }] = useRequestPasswordResetMutation();
+  const [submitted, setSubmitted] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<ForgotPasswordForm>({
+    resolver: zodResolver(forgotPasswordSchema),
+  });
+
+  const onSubmit = async (data: ForgotPasswordForm) => {
+    setError(null);
+    try {
+      await requestReset({ email: data.email }).unwrap();
+      setSubmitted(true);
+      reset();
+    } catch (submissionError: any) {
+      setError(
+        submissionError?.data?.detail ||
+          submissionError?.data?.message ||
+          t('auth.forgotPassword.error')
+      );
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-brand-light flex items-center justify-center py-12 px-4">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="max-w-md w-full"
+      >
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-brand-dark mb-2">
+            {t('auth.forgotPassword.title')}
+          </h1>
+          <p className="text-gray-600">
+            {t('auth.forgotPassword.subtitle')}
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="p-8 space-y-6">
+            {submitted ? (
+              <motion.div
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="rounded-lg border border-green-200 bg-green-50 p-4"
+              >
+                <p className="text-green-700 text-sm">
+                  {t('auth.forgotPassword.successMessage')}
+                </p>
+              </motion.div>
+            ) : null}
+
+            {error ? (
+              <motion.div
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="rounded-lg border border-red-200 bg-red-50 p-4"
+              >
+                <p className="text-red-700 text-sm">{error}</p>
+              </motion.div>
+            ) : null}
+
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+              <Input
+                label={t('auth.login.email')}
+                type="email"
+                placeholder="din.email@example.com"
+                leftIcon={<Mail className="w-4 h-4" />}
+                error={errors.email?.message}
+                fullWidth
+                {...register('email')}
+              />
+
+              <Button type="submit" fullWidth size="lg" isLoading={isLoading}>
+                {t('auth.forgotPassword.submit')}
+              </Button>
+            </form>
+
+            <div className="text-center text-sm text-gray-600">
+              <Link
+                to="/login"
+                className="text-brand-primary hover:text-brand-dark font-medium"
+              >
+                {t('auth.forgotPassword.backToLogin')}
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </motion.div>
+    </div>
+  );
+};

--- a/src/frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/src/frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import { Lock } from 'lucide-react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+
+import { Button, Card, CardContent, Input } from '../../components/ui';
+import { useResetPasswordMutation } from '../../store/api';
+
+const resetSchema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(8, 'Din adgangskode skal være mindst 8 tegn'),
+    confirmPassword: z.string(),
+  })
+  .refine((values) => values.newPassword === values.confirmPassword, {
+    message: 'Adgangskoderne matcher ikke',
+    path: ['confirmPassword'],
+  });
+
+type ResetForm = z.infer<typeof resetSchema>;
+
+const useQuery = () => new URLSearchParams(useLocation().search);
+
+export const ResetPasswordPage: React.FC = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const query = useQuery();
+  const token = query.get('token') || '';
+  const [resetPassword, { isLoading }] = useResetPasswordMutation();
+  const [error, setError] = React.useState<string | null>(null);
+  const [success, setSuccess] = React.useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<ResetForm>({
+    resolver: zodResolver(resetSchema),
+  });
+
+  const onSubmit = async (data: ResetForm) => {
+    if (!token) {
+      setError(t('auth.resetPassword.invalidToken'));
+      return;
+    }
+
+    setError(null);
+    try {
+      await resetPassword({
+        token,
+        newPassword: data.newPassword,
+        confirmPassword: data.confirmPassword,
+      }).unwrap();
+      setSuccess(true);
+      reset();
+      setTimeout(() => navigate('/login'), 2500);
+    } catch (submissionError: any) {
+      setError(
+        submissionError?.data?.detail ||
+          submissionError?.data?.message ||
+          t('auth.resetPassword.error')
+      );
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-brand-light flex items-center justify-center py-12 px-4">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="max-w-md w-full"
+      >
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-brand-dark mb-2">
+            {t('auth.resetPassword.title')}
+          </h1>
+          <p className="text-gray-600">
+            {t('auth.resetPassword.subtitle')}
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="p-8 space-y-6">
+            {success ? (
+              <motion.div
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="rounded-lg border border-green-200 bg-green-50 p-4"
+              >
+                <p className="text-green-700 text-sm">
+                  {t('auth.resetPassword.successMessage')}
+                </p>
+              </motion.div>
+            ) : null}
+
+            {error ? (
+              <motion.div
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="rounded-lg border border-red-200 bg-red-50 p-4"
+              >
+                <p className="text-red-700 text-sm">{error}</p>
+              </motion.div>
+            ) : null}
+
+            <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+              <Input
+                label={t('auth.resetPassword.newPassword')}
+                type="password"
+                placeholder="••••••••"
+                leftIcon={<Lock className="w-4 h-4" />}
+                error={errors.newPassword?.message}
+                fullWidth
+                {...register('newPassword')}
+              />
+
+              <Input
+                label={t('auth.resetPassword.confirmPassword')}
+                type="password"
+                placeholder="••••••••"
+                leftIcon={<Lock className="w-4 h-4" />}
+                error={errors.confirmPassword?.message}
+                fullWidth
+                {...register('confirmPassword')}
+              />
+
+              <Button type="submit" fullWidth size="lg" isLoading={isLoading}>
+                {t('auth.resetPassword.submit')}
+              </Button>
+            </form>
+
+            <div className="text-center text-sm text-gray-600">
+              <Link
+                to="/login"
+                className="text-brand-primary hover:text-brand-dark font-medium"
+              >
+                {t('auth.resetPassword.backToLogin')}
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </motion.div>
+    </div>
+  );
+};

--- a/src/frontend/src/pages/customer/LandingPage.tsx
+++ b/src/frontend/src/pages/customer/LandingPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import {
   Star,
   CheckCircle,
@@ -14,8 +15,8 @@ import {
   MessageCircle
 } from 'lucide-react';
 import { Button } from '@components/ui/Button';
-import { useGetInstagramPostsQuery } from '../../store/api';
-import type { InstagramPost } from '../../types';
+import { useGetInstagramPostsQuery, useGetFeaturedMediaQuery } from '../../store/api';
+import type { InstagramPost, MediaAsset } from '../../types';
 import { mapInstagramPostDto } from '../../utils/instagram';
 
 interface TestimonialProps {
@@ -96,11 +97,17 @@ const ServiceCard: React.FC<ServiceCardProps> = ({
 
 export const LandingPage: React.FC = () => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const {
     data: instagramResponse,
     isLoading: instagramLoading,
     isError: instagramError
   } = useGetInstagramPostsQuery({ limit: 9 });
+  const {
+    data: mediaResponse,
+    isLoading: mediaLoading,
+    isError: mediaError
+  } = useGetFeaturedMediaQuery(6);
 
   const instagramPosts = React.useMemo<InstagramPost[]>(() => {
     if (!instagramResponse?.data) {
@@ -109,6 +116,8 @@ export const LandingPage: React.FC = () => {
 
     return instagramResponse.data.map(mapInstagramPostDto).slice(0, 9);
   }, [instagramResponse]);
+
+  const mediaItems = React.useMemo<MediaAsset[]>(() => mediaResponse ?? [], [mediaResponse]);
 
   const testimonials = [
     {
@@ -241,7 +250,7 @@ export const LandingPage: React.FC = () => {
                 <Button
                   variant="outline"
                   size="lg"
-                  onClick={() => navigate('/services')}
+                  onClick={() => navigate('/tjenester')}
                 >
                   Se Tjenester
                 </Button>
@@ -318,7 +327,7 @@ export const LandingPage: React.FC = () => {
             <Button
               variant="outline"
               size="lg"
-              onClick={() => navigate('/services')}
+              onClick={() => navigate('/tjenester')}
               rightIcon={<ArrowRight className="h-5 w-5" />}
             >
               Se Alle Tjenester
@@ -516,6 +525,79 @@ export const LandingPage: React.FC = () => {
           ) : (
             <div className="rounded-xl border border-dashed border-brand-primary/40 bg-brand-accent/40 p-6 text-brand-dark">
               Ingen Instagram-opslag er fremhævet endnu. Tjek igen senere for nye transformationer.
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Media Spotlight Section */}
+      <section className="section-padding bg-brand-light">
+        <div className="container-custom">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="mb-12 text-center"
+          >
+            <h2 className="text-3xl md:text-4xl font-serif font-bold text-brand-dark mb-4">
+              {t('landing.media.title')}
+            </h2>
+            <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+              {t('landing.media.subtitle')}
+            </p>
+          </motion.div>
+
+          {mediaLoading ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {Array.from({ length: 6 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="aspect-square rounded-xl bg-white border border-brown-100 shadow-soft animate-pulse"
+                />
+              ))}
+            </div>
+          ) : mediaError ? (
+            <div className="rounded-xl border border-dashed border-brand-primary/40 bg-brand-accent/40 p-6 text-brand-dark">
+              {t('landing.media.error')}
+            </div>
+          ) : mediaItems.length ? (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+            >
+              {mediaItems.map((item) => (
+                <motion.figure
+                  key={item.id}
+                  className="relative overflow-hidden rounded-xl shadow-soft border border-brown-100 bg-white"
+                  whileHover={{ scale: 1.01 }}
+                >
+                  {item.mimeType.startsWith('video/') ? (
+                    <video
+                      src={item.url}
+                      controls
+                      className="w-full h-72 object-cover"
+                    />
+                  ) : (
+                    <img
+                      src={item.url}
+                      alt={item.altText ?? item.originalFilename}
+                      className="w-full h-72 object-cover"
+                      loading="lazy"
+                    />
+                  )}
+                  {item.caption ? (
+                    <figcaption className="p-3 text-sm text-gray-700 bg-white/90">
+                      {item.caption}
+                    </figcaption>
+                  ) : null}
+                </motion.figure>
+              ))}
+            </motion.div>
+          ) : (
+            <div className="rounded-xl border border-dashed border-brand-primary/40 bg-brand-accent/40 p-6 text-brand-dark">
+              {t('landing.media.empty')}
             </div>
           )}
         </div>

--- a/src/frontend/src/pages/customer/ServicesCatalogPage.tsx
+++ b/src/frontend/src/pages/customer/ServicesCatalogPage.tsx
@@ -1,0 +1,306 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import { Clock3, ArrowRightCircle, Sparkles, Play } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import {
+  useGetServiceCategoriesQuery,
+  useGetServicesQuery,
+  useGetFeaturedMediaQuery,
+} from '../../store/api';
+import type { Service, ServiceCategory, MediaAsset } from '../../types';
+import { formatCurrency } from '../../i18n';
+
+const filterServicesByCategory = (
+  services: Service[],
+  categoryId?: string | null
+) => {
+  if (!categoryId || categoryId === 'all') {
+    return services;
+  }
+
+  return services.filter((service) => {
+    const serviceCategoryId =
+      service.category?.id ?? (service as any).categoryId ?? (service as any).category_id ?? null;
+
+    return serviceCategoryId === categoryId;
+  });
+};
+
+const useLocalizedText = () => {
+  const { i18n } = useTranslation();
+
+  return React.useCallback(
+    (primary?: string | null, secondary?: string | null) => {
+      if (i18n.language.startsWith('en')) {
+        return secondary ?? primary ?? '';
+      }
+
+      return primary ?? secondary ?? '';
+    },
+    [i18n.language]
+  );
+};
+
+const ServicesGrid: React.FC<{
+  services: Service[];
+}> = ({ services }) => {
+  const { t } = useTranslation();
+  const getLocalizedText = useLocalizedText();
+
+  if (!services.length) {
+    return (
+      <div className="rounded-2xl border border-dashed border-brown-200 bg-brand-accent/40 p-8 text-center text-gray-600">
+        {t('services.emptyState')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+      {services.map((service) => {
+        const name = getLocalizedText(
+          service.name,
+          service.nameEn ?? (service as any).nameEn ?? (service as any).name_en ?? undefined
+        );
+        const description = getLocalizedText(
+          service.description,
+          service.descriptionEn ?? (service as any).descriptionEn ?? (service as any).description_en ?? undefined
+        );
+        const servicePrice = service.price ?? (service as any).base_price ?? 0;
+        const serviceDuration = service.duration ?? (service as any).duration_minutes ?? 0;
+        const requirements: string[] =
+          service.requirements ?? (service as any).requirements ?? [];
+        const aftercare: string[] = service.aftercare ?? (service as any).aftercare ?? [];
+
+        return (
+          <motion.div
+            key={service.id}
+            whileHover={{ y: -4, boxShadow: '0 20px 30px -15px rgba(107,78,50,0.35)' }}
+            className="bg-white rounded-2xl border border-brown-100 shadow-soft overflow-hidden flex flex-col"
+          >
+            <div className="p-6 flex-1 flex flex-col">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-xl font-semibold text-brand-dark">
+                    {name || service.name}
+                  </h3>
+                  {description ? (
+                    <p className="mt-2 text-gray-600 leading-relaxed">
+                      {description}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="text-right">
+                  <p className="text-brand-primary font-serif text-2xl">
+                    {formatCurrency(servicePrice)}
+                  </p>
+                  <p className="text-sm text-gray-500 inline-flex items-center gap-1">
+                    <Clock3 className="w-4 h-4" />
+                    {serviceDuration} min
+                  </p>
+                </div>
+              </div>
+
+              {requirements.length ? (
+                <div className="mt-4">
+                  <h4 className="text-sm font-semibold text-brand-dark mb-1">
+                    {t('services.requirements')}
+                  </h4>
+                  <ul className="text-sm text-gray-600 list-disc list-inside space-y-1">
+                    {requirements.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              {aftercare.length ? (
+                <div className="mt-4">
+                  <h4 className="text-sm font-semibold text-brand-dark mb-1">
+                    {t('services.aftercare')}
+                  </h4>
+                  <ul className="text-sm text-gray-600 list-disc list-inside space-y-1">
+                    {aftercare.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </div>
+
+            <div className="px-6 pb-6">
+              <Link
+                to={`/book?serviceId=${service.id}`}
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-brand-primary text-white px-4 py-2 text-sm font-medium hover:bg-brand-dark transition"
+              >
+                {t('services.bookCta')}
+                <ArrowRightCircle className="w-4 h-4" />
+              </Link>
+            </div>
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+};
+
+const MediaSpotlight: React.FC<{ media: MediaAsset[] }> = ({ media }) => {
+  const { t } = useTranslation();
+
+  if (!media.length) {
+    return null;
+  }
+
+  return (
+    <section className="mt-16">
+      <div className="flex items-center gap-3 mb-6">
+        <div className="w-10 h-10 rounded-full bg-brand-primary/10 text-brand-primary flex items-center justify-center">
+          <Sparkles className="w-5 h-5" />
+        </div>
+        <div>
+          <h2 className="text-2xl font-serif font-bold text-brand-dark">
+            {t('services.media.title')}
+          </h2>
+          <p className="text-sm text-gray-600">
+            {t('services.media.subtitle')}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+        {media.map((item) => (
+          <motion.figure
+            key={item.id}
+            whileHover={{ scale: 1.02 }}
+            className="relative overflow-hidden rounded-2xl shadow-soft border border-brown-100"
+          >
+            {item.mimeType.startsWith('video/') ? (
+              <video
+                src={item.url}
+                controls
+                className="w-full h-64 object-cover"
+              />
+            ) : (
+              <img
+                src={item.url}
+                alt={item.altText ?? item.originalFilename}
+                className="w-full h-64 object-cover"
+                loading="lazy"
+              />
+            )}
+            {item.caption ? (
+              <figcaption className="p-4 text-sm text-gray-700 bg-white/90">
+                {item.caption}
+              </figcaption>
+            ) : null}
+            {item.mimeType.startsWith('video/') ? (
+              <div className="absolute top-3 left-3 inline-flex items-center gap-1 rounded-full bg-black/70 px-3 py-1 text-xs text-white">
+                <Play className="w-3.5 h-3.5" />
+                {t('services.media.videoBadge')}
+              </div>
+            ) : null}
+          </motion.figure>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export const ServicesCatalogPage: React.FC = () => {
+  const { t, i18n } = useTranslation();
+  const { data: categoryResponse } = useGetServiceCategoriesQuery();
+  const { data: servicesResponse, isLoading } = useGetServicesQuery({ isActive: true });
+  const { data: media } = useGetFeaturedMediaQuery(6);
+
+  const categories: ServiceCategory[] = categoryResponse?.data ?? [];
+  const services: Service[] = servicesResponse?.data ?? [];
+  const mediaItems = media ?? [];
+
+  const [selectedCategory, setSelectedCategory] = React.useState<string>('all');
+  const filteredServices = React.useMemo(
+    () => filterServicesByCategory(services, selectedCategory),
+    [services, selectedCategory]
+  );
+
+  return (
+    <div className="bg-brand-light py-16">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <header className="mb-12 text-center">
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-brand-primary/10 text-brand-primary text-sm font-medium"
+          >
+            <Sparkles className="w-4 h-4" />
+            {t('services.heroBadge')}
+          </motion.div>
+          <motion.h1
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mt-4 text-4xl font-serif font-bold text-brand-dark"
+          >
+            {t('services.heroTitle')}
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mt-4 text-lg text-gray-600 max-w-2xl mx-auto"
+          >
+            {t('services.heroSubtitle')}
+          </motion.p>
+        </header>
+
+        <nav className="flex flex-wrap gap-3 justify-center mb-12">
+          <button
+            type="button"
+            onClick={() => setSelectedCategory('all')}
+            className={`px-4 py-2 rounded-full text-sm font-medium transition border ${
+              selectedCategory === 'all'
+                ? 'bg-brand-primary text-white border-brand-primary'
+                : 'bg-white text-brand-dark border-brown-200 hover:border-brand-primary/40'
+            }`}
+          >
+            {t('services.allServices')}
+          </button>
+          {categories.map((category) => {
+            const displayName = i18n.language.startsWith('en')
+              ? category.nameEn ?? (category as any).name_en ?? category.name
+              : category.name;
+
+            return (
+              <button
+                key={category.id}
+                type="button"
+                onClick={() => setSelectedCategory(category.id)}
+                className={`px-4 py-2 rounded-full text-sm font-medium transition border ${
+                  selectedCategory === category.id
+                    ? 'bg-brand-primary text-white border-brand-primary'
+                    : 'bg-white text-brand-dark border-brown-200 hover:border-brand-primary/40'
+                }`}
+              >
+                {displayName}
+              </button>
+            );
+          })}
+        </nav>
+
+        {isLoading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-64 rounded-2xl bg-white border border-brown-100 shadow-soft animate-pulse"
+              />
+            ))}
+          </div>
+        ) : (
+          <ServicesGrid services={filteredServices} />
+        )}
+
+        <MediaSpotlight media={mediaItems} />
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/src/pages/legal/TermsPage.tsx
+++ b/src/frontend/src/pages/legal/TermsPage.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import { Shield, FileText, RefreshCw } from 'lucide-react';
+
+import { useGetCmsPageQuery } from '../../store/api';
+import type { CmsPage } from '../../types';
+
+const renderContent = (page: CmsPage | undefined | null, fallbackSections: { title: string; content: string }[]) => {
+  if (!page?.content) {
+    return (
+      <div className="space-y-8">
+        {fallbackSections.map((section) => (
+          <section key={section.title}>
+            <h2 className="text-xl font-semibold text-brand-dark mb-2">
+              {section.title}
+            </h2>
+            <p className="text-gray-700 leading-relaxed">{section.content}</p>
+          </section>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="prose prose-brand max-w-none"
+      dangerouslySetInnerHTML={{ __html: page.content }}
+    />
+  );
+};
+
+export const TermsPage: React.FC = () => {
+  const { t } = useTranslation();
+  const { data, isLoading, isError } = useGetCmsPageQuery('terms-of-service');
+  const page = data;
+  const fallbackSections = React.useMemo(
+    () => [
+      {
+        title: t('legal.terms.fallback.processingTitle'),
+        content: t('legal.terms.fallback.processingText')
+      },
+      {
+        title: t('legal.terms.fallback.rightsTitle'),
+        content: t('legal.terms.fallback.rightsText')
+      },
+      {
+        title: t('legal.terms.fallback.cookiesTitle'),
+        content: t('legal.terms.fallback.cookiesText')
+      }
+    ],
+    [t]
+  );
+
+  return (
+    <div className="bg-brand-light py-16">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="bg-white rounded-3xl shadow-soft border border-brown-100 overflow-hidden"
+        >
+          <div className="bg-brand-primary/10 p-8 border-b border-brown-100">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+              <div className="flex items-center gap-4">
+                <div className="w-12 h-12 rounded-full bg-brand-primary text-white flex items-center justify-center">
+                  <Shield className="w-6 h-6" />
+                </div>
+                <div>
+                  <h1 className="text-3xl font-serif font-bold text-brand-dark">
+                    {page?.title ?? t('legal.terms.title')}
+                  </h1>
+                  <p className="text-gray-600 mt-1">
+                    {page?.excerpt ?? t('legal.terms.subtitle')}
+                  </p>
+                </div>
+              </div>
+              <div className="flex flex-col items-start md:items-end gap-2 text-sm text-gray-600">
+                <div className="inline-flex items-center gap-2">
+                  <FileText className="w-4 h-4" />
+                  <span>{t('legal.terms.version', { version: page?.gdprVersion ?? '1.0' })}</span>
+                </div>
+                {page?.publishedAt ? (
+                  <div className="inline-flex items-center gap-2">
+                    <RefreshCw className="w-4 h-4" />
+                    <span>
+                      {t('legal.terms.updated', {
+                        date: new Date(page.publishedAt).toLocaleDateString('da-DK')
+                      })}
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="p-8">
+            {isLoading ? (
+              <p className="text-gray-600">{t('common.loading')}</p>
+            ) : isError ? (
+              <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700">
+                {t('legal.terms.error')}
+              </div>
+            ) : (
+              renderContent(page, fallbackSections)
+            )}
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -284,6 +284,65 @@ export interface PageContent {
   updatedAt: string;
 }
 
+export type CmsPageType =
+  | 'page'
+  | 'blog_post'
+  | 'service_page'
+  | 'product_page'
+  | 'landing_page';
+
+export interface CmsPageSummary {
+  id: string;
+  title: string;
+  slug: string;
+  pageType: CmsPageType;
+  isPublished: boolean;
+  publishedAt?: string | null;
+  updatedAt: string;
+}
+
+export interface CmsPage extends CmsPageSummary {
+  content?: string | null;
+  excerpt?: string | null;
+  metaTitle?: string | null;
+  metaDescription?: string | null;
+  metaKeywords?: string[] | null;
+  gdprVersion?: string | null;
+  heroMedia?: MediaAsset | null;
+}
+
+export interface MediaAsset {
+  id: string;
+  url: string;
+  originalFilename: string;
+  mimeType: string;
+  fileSize: number;
+  altText?: string | null;
+  caption?: string | null;
+  isFeatured: boolean;
+  displayOrder: number;
+  isPublished: boolean;
+  publishedAt: string;
+}
+
+export interface MediaAssetAdmin extends MediaAsset {
+  filename: string;
+  filePath: string;
+  fileSizeMb: number;
+  uploadedBy?: string | null;
+  uploadedAt: string;
+}
+
+export interface PasswordResetRequestPayload {
+  email: string;
+}
+
+export interface PasswordResetConfirmPayload {
+  token: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
 // WebSocket types
 export interface SocketEvent {
   type: 'appointment_update' | 'new_booking' | 'availability_change' | 'user_update';


### PR DESCRIPTION
## Summary
- add CMS and media API endpoints with dedicated schemas and services to serve GDPR content and uploaded assets
- surface public services, terms, forgot/reset password flows, and media gallery pages with localized navigation updates
- extend the admin CMS to manage uploaded media alongside existing Instagram content

## Testing
- npm run lint *(fails: existing lint violations in unrelated admin components)*

------
https://chatgpt.com/codex/tasks/task_b_68daec6c77f883308c1b7e80ec7a6110