### PR TITLE
Ensure email template ids generate automatically

### DIFF
--- a/src/db/012_fix_email_templates_id_default.sql
+++ b/src/db/012_fix_email_templates_id_default.sql
@@ -1,0 +1,12 @@
+-- Migration 012: Ensure email_templates.id has default UUID generation
+-- This migration addresses cases where the id column lacks a default,
+-- causing inserts that omit the id value to fail.
+
+ALTER TABLE email_templates
+    ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+
+-- Backfill any rows that still have NULL ids (should not normally occur),
+-- assigning new UUIDs just in case.
+UPDATE email_templates
+SET id = uuid_generate_v4()
+WHERE id IS NULL;


### PR DESCRIPTION
## Summary
- add migration to enforce a uuid_generate_v4 default for email_templates.id
- backfill any NULL ids to prevent future inserts from failing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbf36b91708330894ce5a97c93d448