### PR TITLE
Fix booking page import failure in Vite

### DIFF
--- a/src/frontend/src/components/booking/BookingWizard.tsx
+++ b/src/frontend/src/components/booking/BookingWizard.tsx
@@ -155,7 +155,7 @@ export const BookingWizard: React.FC = () => {
         </Card>
 
         {/* Debug info (development only) */}
-        {process.env.NODE_ENV === 'development' && (
+        {import.meta.env.DEV && (
           <div className="mt-8 p-4 bg-gray-100 rounded-lg text-xs text-gray-600">
             <details>
               <summary className="cursor-pointer font-medium">Debug Info</summary>

--- a/src/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/src/frontend/src/components/ui/ErrorBoundary.tsx
@@ -2,6 +2,8 @@ import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { Button } from './Button';
 
+const IS_DEVELOPMENT = import.meta.env.DEV;
+
 interface Props {
   children: ReactNode;
   fallback?: ReactNode;
@@ -72,7 +74,7 @@ export class ErrorBoundary extends Component<Props, State> {
                 </Button>
               </div>
 
-              {process.env.NODE_ENV === 'development' && (
+              {IS_DEVELOPMENT && (
                 <details className="mt-6 text-left">
                   <summary className="cursor-pointer text-sm text-gray-500 hover:text-gray-700">
                     Error Details (Development)


### PR DESCRIPTION
## Summary
- replace direct process.env checks with Vite-compatible import.meta.env usage in booking wizard
- update the global error boundary to rely on the same Vite development flag so lazy-loaded pages evaluate correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dbf85cfaa88330aa7f6d0173f7daf3