### PR TITLE
Fix Card component motion props warnings

### DIFF
--- a/src/frontend/src/components/ui/Card.tsx
+++ b/src/frontend/src/components/ui/Card.tsx
@@ -71,18 +71,20 @@ export const Card: React.FC<CardProps> = ({
     className
   );
 
-  const CardComponent = onClick ? motion.div : 'div';
+  if (onClick) {
+    return (
+      <motion.div
+        className={cardClasses}
+        onClick={onClick}
+        whileHover={hover ? { scale: 1.02 } : undefined}
+        whileTap={hover ? { scale: 0.98 } : undefined}
+      >
+        {children}
+      </motion.div>
+    );
+  }
 
-  return (
-    <CardComponent
-      className={cardClasses}
-      onClick={onClick}
-      whileHover={hover && onClick ? { scale: 1.02 } : undefined}
-      whileTap={hover && onClick ? { scale: 0.98 } : undefined}
-    >
-      {children}
-    </CardComponent>
-  );
+  return <div className={cardClasses}>{children}</div>;
 };
 
 export interface CardHeaderProps {


### PR DESCRIPTION
## Summary
- render the Card as a motion.div only when an onClick handler is supplied so motion props stay on motion elements
- keep a plain div for non-clickable cards to avoid React warnings about whileHover/whileTap

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68dc1033b2e48330996294fbede72d02