### PR TITLE
Add Brevo transactional email support

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -85,6 +85,8 @@ SMTP_FROM=982547001@smtp-brevo.com
 SMTP_FROM_NAME="Loctician Booking System"
 SMTP_STARTTLS=true
 SMTP_SSL=false
+BREVO_API_KEY=
+BREVO_API_BASE_URL=https://api.brevo.com/v3
 
 # =============================================================================
 # FILE UPLOAD CONFIGURATION

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -84,6 +84,8 @@ class Settings(BaseSettings):
     SMTP_FROM_NAME: str = "Loctician Booking"
     SMTP_STARTTLS: bool = True
     SMTP_SSL: bool = False
+    BREVO_API_KEY: Optional[str] = None
+    BREVO_API_BASE_URL: str = "https://api.brevo.com/v3"
 
     # File Upload
     MAX_FILE_SIZE_MB: int = 10

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -30,3 +30,4 @@ psutil==5.9.8
 pydantic-settings==2.11.0
 mollie-api-python==3.8.0
 python-multipart>=0.0.9
+sib-api-v3-sdk==7.6.0


### PR DESCRIPTION
## Summary
- add Brevo transactional email client integration with async fallback to SMTP
- expose Brevo API settings and sample env configuration
- include Brevo SDK dependency for backend services

## Testing
- `pytest src/backend/tests` *(fails: existing Mollie integration tests)*

------
https://chatgpt.com/codex/tasks/task_b_68dc135a1fb88330bc5af5d08d5142db