### PR TITLE
Add default email templates for marketing and internal notifications

### DIFF
--- a/src/backend/app/models/enums.py
+++ b/src/backend/app/models/enums.py
@@ -74,6 +74,9 @@ class TemplateType(str, enum.Enum):
     PASSWORD_RESET = "PASSWORD_RESET"
     MARKETING = "MARKETING"
     INVOICE = "INVOICE"
+    CONTACT = "CONTACT"
+    ADMIN_NOTIFICATION = "ADMIN_NOTIFICATION"
+    STAFF_NOTIFICATION = "STAFF_NOTIFICATION"
 
 
 class EmailStatus(str, enum.Enum):

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -59,6 +59,7 @@ from app.utils.enhanced_errors import (
 from pydantic import ValidationError
 from app.core.config import settings
 from app.core.database import close_db, db_health, init_db
+from app.services.email_service import email_service
 
 # Configure structured logging
 structlog.configure(
@@ -102,6 +103,10 @@ async def lifespan(_: FastAPI):
         else:
             logger.error("Database health check failed")
             raise Exception("Database health check failed")
+
+        # Ensure required email templates are available
+        await email_service.ensure_default_templates()
+        logger.info("Default email templates ensured")
 
         logger.info("Application startup completed")
 

--- a/src/backend/tests/test_email_templates.py
+++ b/src/backend/tests/test_email_templates.py
@@ -1,0 +1,64 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from app.services.email_service import email_service, DEFAULT_TEMPLATES
+from app.models.enums import TemplateType
+
+
+@pytest.mark.asyncio
+async def test_ensure_default_templates_creates_missing(monkeypatch):
+    """Missing templates should trigger creation using provided session."""
+
+    original_templates = email_service.default_templates
+    sample_templates = {
+        TemplateType.MARKETING: DEFAULT_TEMPLATES[TemplateType.MARKETING],
+        TemplateType.CONTACT: DEFAULT_TEMPLATES[TemplateType.CONTACT],
+    }
+    email_service.default_templates = sample_templates
+
+    create_mock = AsyncMock()
+    get_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(email_service, "create_template", create_mock)
+    monkeypatch.setattr(email_service, "get_template", get_mock)
+
+    session = AsyncMock()
+    try:
+        await email_service.ensure_default_templates(session=session)
+    finally:
+        email_service.default_templates = original_templates
+
+    assert create_mock.await_count == len(sample_templates)
+    for call in create_mock.await_args_list:
+        kwargs = call.kwargs
+        assert kwargs["session"] is session
+        assert kwargs["template_type"] in sample_templates
+
+
+@pytest.mark.asyncio
+async def test_ensure_default_templates_skips_when_current(monkeypatch):
+    """Existing templates with matching content should not be recreated."""
+
+    original_templates = email_service.default_templates
+    template_type = TemplateType.MARKETING
+    template_data = DEFAULT_TEMPLATES[template_type]
+    email_service.default_templates = {template_type: template_data}
+
+    existing = SimpleNamespace(
+        subject=template_data["subject"],
+        html_content=template_data["html_content"],
+        text_content=template_data.get("text_content"),
+        version=1,
+    )
+
+    monkeypatch.setattr(email_service, "get_template", AsyncMock(return_value=existing))
+    create_mock = AsyncMock()
+    monkeypatch.setattr(email_service, "create_template", create_mock)
+
+    session = AsyncMock()
+    try:
+        await email_service.ensure_default_templates(session=session)
+    finally:
+        email_service.default_templates = original_templates
+
+    create_mock.assert_not_awaited()

--- a/src/db/013_update_email_template_enum.sql
+++ b/src/db/013_update_email_template_enum.sql
@@ -1,0 +1,30 @@
+-- Migration 013: Extend templatetype enum with contact and internal notifications
+-- Ensures email workflows cover marketing, contact, admin, and staff use cases
+DO $$
+BEGIN
+    -- Add new values if they do not already exist
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+        WHERE t.typname = 'templatetype' AND e.enumlabel = 'CONTACT'
+    ) THEN
+        ALTER TYPE templatetype ADD VALUE 'CONTACT';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+        WHERE t.typname = 'templatetype' AND e.enumlabel = 'ADMIN_NOTIFICATION'
+    ) THEN
+        ALTER TYPE templatetype ADD VALUE 'ADMIN_NOTIFICATION';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+        WHERE t.typname = 'templatetype' AND e.enumlabel = 'STAFF_NOTIFICATION'
+    ) THEN
+        ALTER TYPE templatetype ADD VALUE 'STAFF_NOTIFICATION';
+    END IF;
+END
+$$;

--- a/src/db/sample_data.sql
+++ b/src/db/sample_data.sql
@@ -315,66 +315,163 @@ INSERT INTO bookings (
 -- =====================================================
 
 INSERT INTO email_templates (name, template_type, subject, html_content, text_content, available_variables) VALUES
-('Booking Confirmation', 'booking_confirmation',
- 'Booking Confirmed - {{booking_number}}',
- '<h2>Booking Confirmed</h2>
-  <p>Dear {{customer_name}},</p>
-  <p>Your appointment has been confirmed:</p>
+('Booking Confirmation', 'BOOKING_CONFIRMATION',
+ 'Booking bekræftet – {{booking_number}}',
+ '<h2>Booking bekræftet</h2>
+  <p>Kære {{customer_name}},</p>
+  <p>Din tid er nu bekræftet:</p>
   <ul>
     <li><strong>Service:</strong> {{service_name}}</li>
-    <li><strong>Date & Time:</strong> {{appointment_date}} at {{appointment_time}}</li>
-    <li><strong>Duration:</strong> {{duration}} minutes</li>
+    <li><strong>Dato & tidspunkt:</strong> {{appointment_date}} kl. {{appointment_time}}</li>
+    <li><strong>Varighed:</strong> {{duration}} minutter</li>
     <li><strong>Loctician:</strong> {{loctician_name}}</li>
-    <li><strong>Total:</strong> {{total_amount}} DKK</li>
+    <li><strong>Pris:</strong> {{total_amount}} DKK</li>
   </ul>
-  <p>Please arrive 15 minutes early.</p>
-  <p>Best regards,<br>{{business_name}}</p>',
- 'Booking Confirmed - {{booking_number}}
+  <p>Vi glæder os til at se dig. Kom gerne 15 minutter før din tid.</p>
+  <p>Varme hilsner,<br>{{business_name}}</p>',
+ 'Booking bekræftet – {{booking_number}}
 
-Dear {{customer_name}},
+Kære {{customer_name}},
 
-Your appointment has been confirmed:
+Din tid er nu bekræftet:
 - Service: {{service_name}}
-- Date & Time: {{appointment_date}} at {{appointment_time}}
-- Duration: {{duration}} minutes
+- Dato & tidspunkt: {{appointment_date}} kl. {{appointment_time}}
+- Varighed: {{duration}} minutter
 - Loctician: {{loctician_name}}
-- Total: {{total_amount}} DKK
+- Pris: {{total_amount}} DKK
 
-Please arrive 15 minutes early.
+Vi glæder os til at se dig. Kom gerne 15 minutter før din tid.
 
-Best regards,
+Varme hilsner,
 {{business_name}}',
- '{"customer_name": "Customer full name", "booking_number": "Booking reference", "service_name": "Name of booked service", "appointment_date": "Date of appointment", "appointment_time": "Time of appointment", "duration": "Service duration in minutes", "loctician_name": "Loctician full name", "total_amount": "Total price", "business_name": "Business name"}'),
+ '{"customer_name": "Kundens fulde navn", "booking_number": "Bookingreference", "service_name": "Navn på booket service", "appointment_date": "Aftalens dato", "appointment_time": "Aftalens tidspunkt", "duration": "Varighed i minutter", "loctician_name": "Locticians navn", "total_amount": "Pris", "business_name": "Virksomhedsnavn"}'),
 
-('Appointment Reminder', 'reminder',
- 'Reminder: Your appointment tomorrow - {{booking_number}}',
- '<h2>Appointment Reminder</h2>
-  <p>Dear {{customer_name}},</p>
-  <p>This is a friendly reminder about your appointment tomorrow:</p>
+('Appointment Reminder', 'REMINDER',
+ 'Påmindelse: Din aftale i morgen – {{booking_number}}',
+ '<h2>Vi ses snart!</h2>
+  <p>Kære {{customer_name}},</p>
+  <p>Dette er en venlig påmindelse om din aftale i morgen:</p>
   <ul>
     <li><strong>Service:</strong> {{service_name}}</li>
-    <li><strong>Date & Time:</strong> {{appointment_date}} at {{appointment_time}}</li>
+    <li><strong>Dato & tidspunkt:</strong> {{appointment_date}} kl. {{appointment_time}}</li>
     <li><strong>Loctician:</strong> {{loctician_name}}</li>
   </ul>
-  <p>Please arrive 15 minutes early and bring any special products if discussed.</p>
-  <p>Looking forward to seeing you!</p>
-  <p>Best regards,<br>{{business_name}}</p>',
- 'Appointment Reminder
+  <p>Har du særlige ønsker, så giv os endelig besked.</p>
+  <p>Bedste hilsner,<br>{{business_name}}</p>',
+ 'Påmindelse: Din aftale i morgen – {{booking_number}}
 
-Dear {{customer_name}},
+Kære {{customer_name}},
 
-This is a friendly reminder about your appointment tomorrow:
+Dette er en venlig påmindelse om din aftale i morgen:
 - Service: {{service_name}}
-- Date & Time: {{appointment_date}} at {{appointment_time}}
+- Dato & tidspunkt: {{appointment_date}} kl. {{appointment_time}}
 - Loctician: {{loctician_name}}
 
-Please arrive 15 minutes early and bring any special products if discussed.
+Har du særlige ønsker, så giv os endelig besked.
 
-Looking forward to seeing you!
-
-Best regards,
+Bedste hilsner,
 {{business_name}}',
- '{"customer_name": "Customer full name", "booking_number": "Booking reference", "service_name": "Name of booked service", "appointment_date": "Date of appointment", "appointment_time": "Time of appointment", "loctician_name": "Loctician full name", "business_name": "Business name"}');
+ '{"customer_name": "Kundens fulde navn", "booking_number": "Bookingreference", "service_name": "Navn på booket service", "appointment_date": "Aftalens dato", "appointment_time": "Aftalens tidspunkt", "loctician_name": "Locticians navn", "business_name": "Virksomhedsnavn"}'),
+
+('Booking Cancellation', 'CANCELLATION',
+ 'Din booking er aflyst – {{booking_number}}',
+ '<h2>Booking aflyst</h2>
+  <p>Kære {{customer_name}},</p>
+  <p>Vi bekræfter hermed, at din booking {{booking_number}} er aflyst.</p>
+  <p><strong>Årsag:</strong> {{cancellation_reason}}</p>
+  <p>Kontakt os gerne, hvis du ønsker at booke en ny tid.</p>
+  <p>Venlig hilsen,<br>{{business_name}}</p>',
+ 'Din booking er aflyst – {{booking_number}}
+
+Kære {{customer_name}},
+
+Vi bekræfter hermed, at din booking {{booking_number}} er aflyst.
+Årsag: {{cancellation_reason}}
+
+Kontakt os gerne, hvis du ønsker at booke en ny tid.
+
+Venlig hilsen,
+{{business_name}}',
+ '{"customer_name": "Kundens fulde navn", "booking_number": "Bookingreference", "cancellation_reason": "Aflysningsårsag", "business_name": "Virksomhedsnavn"}'),
+
+('Marketing Inspiration', 'MARKETING',
+ 'EKSKLUSIVE OPDATERINGER – Nyheder fra dit loctician team',
+ '<h1>EKSKLUSIVE OPDATERINGER</h1>
+  <p><strong>Hold dig opdateret</strong></p>
+  <p>Få de seneste tips, trends og særlige tilbud direkte i din indbakke. Vi lover kun inspirerende hårpleje.</p>
+  <p>{{custom_message}}</p>
+  <p><em>{{special_offer}}</em></p>
+  <p><a href="{{cta_url}}" style="color:#a67c52; font-weight:bold;">{{cta_label}}</a></p>
+  <p>Tak fordi du er en del af vores community.<br>{{business_name}}</p>',
+ 'EKSKLUSIVE OPDATERINGER
+
+Hold dig opdateret
+
+Få de seneste tips, trends og særlige tilbud direkte i din indbakke. Vi lover kun inspirerende hårpleje.
+
+{{custom_message}}
+
+{{special_offer}}
+
+Læs mere: {{cta_url}}
+
+Tak fordi du er en del af vores community.
+{{business_name}}',
+ '{"custom_message": "Valgfri ekstra besked", "special_offer": "Eventuel kampagne", "cta_label": "Tekst til call-to-action", "cta_url": "Link til kampagne", "business_name": "Virksomhedsnavn"}'),
+
+('Kontaktbesked', 'CONTACT',
+ 'Ny kontaktforespørgsel fra {{sender_name}}',
+ '<h2>Ny kontaktforespørgsel</h2>
+  <p><strong>Navn:</strong> {{sender_name}}</p>
+  <p><strong>Email:</strong> {{sender_email}}</p>
+  <p><strong>Telefon:</strong> {{sender_phone}}</p>
+  <p><strong>Emne:</strong> {{topic}}</p>
+  <p>{{message_body}}</p>',
+ 'Ny kontaktforespørgsel
+
+Navn: {{sender_name}}
+Email: {{sender_email}}
+Telefon: {{sender_phone}}
+Emne: {{topic}}
+
+{{message_body}}',
+ '{"sender_name": "Afsenders navn", "sender_email": "Afsenders email", "sender_phone": "Telefonnummer", "topic": "Emne", "message_body": "Selve beskeden"}'),
+
+('Intern admin notifikation', 'ADMIN_NOTIFICATION',
+ 'Administrativ hændelse: {{subject}}',
+ '<h2>Administrativ notifikation</h2>
+  <p>{{subject}}</p>
+  <p>{{message_body}}</p>
+  <p><strong>Dato:</strong> {{timestamp}}</p>
+  <p><strong>Detaljer:</strong></p>
+  <pre>{{metadata}}</pre>',
+ 'Administrativ notifikation
+
+{{subject}}
+
+{{message_body}}
+
+Dato: {{timestamp}}
+Detaljer:
+{{metadata}}',
+ '{"subject": "Kort overskrift", "message_body": "Notifikationstekst", "timestamp": "Tidspunkt", "metadata": "Supplerende information"}'),
+
+('Intern staff notifikation', 'STAFF_NOTIFICATION',
+ 'Teamopdatering: {{subject}}',
+ '<h2>Teamopdatering</h2>
+  <p>{{subject}}</p>
+  <p>{{message_body}}</p>
+  <p><strong>Dato:</strong> {{timestamp}}</p>
+  <p>Kontakt admin ved spørgsmål.</p>',
+ 'Teamopdatering
+
+{{subject}}
+
+{{message_body}}
+
+Dato: {{timestamp}}
+Kontakt admin ved spørgsmål.',
+ '{"subject": "Kort overskrift", "message_body": "Notifikationstekst", "timestamp": "Tidspunkt"}');
 
 -- =====================================================
 -- CMS CONTENT

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -472,7 +472,10 @@ CREATE TYPE templatetype AS ENUM (
     'WELCOME',
     'PASSWORD_RESET',
     'MARKETING',
-    'INVOICE'
+    'INVOICE',
+    'CONTACT',
+    'ADMIN_NOTIFICATION',
+    'STAFF_NOTIFICATION'
 );
 
 CREATE TABLE email_templates (


### PR DESCRIPTION
## Summary
- extend the email template enum and schema to cover marketing, contact, and internal notification flows
- seed comprehensive default templates (including Danish marketing copy) and ensure they are installed automatically at startup
- add service helpers and tests for marketing blasts, contact routing, and admin/staff notifications while refreshing booking email subjects

## Testing
- python -m pytest tests/test_email_templates.py

------
https://chatgpt.com/codex/tasks/task_b_68dc23f8630883309ca38c28e3219e72