### PR TITLE
Integrate Upstash Redis support for caching

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -26,6 +26,12 @@ DB_POOL_RECYCLE=300
 # Redis URL for caching and session storage
 REDIS_URL=redis://localhost:6379/0
 
+# Upstash Redis REST API credentials (optional)
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+# Optional read-only token for safe GET-only operations
+UPSTASH_REDIS_REST_READONLY_TOKEN=
+
 # =============================================================================
 # SECURITY CONFIGURATION
 # =============================================================================

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -68,6 +68,7 @@ src/backend/
 - Python 3.8+
 - PostgreSQL 12+
 - Redis 6+ (optional, for advanced caching)
+- Upstash Redis account (optional, for managed serverless caching)
 
 ### 1. Environment Setup
 
@@ -142,6 +143,11 @@ The application uses environment variables for configuration. See `.env.example`
 - `RATE_LIMIT_PER_MINUTE`: API rate limiting (default: 60)
 - `CORS_ORIGINS`: Allowed CORS origins
 - `JWT_JWKS_URL` / `JWT_ALLOWED_ALGORITHMS` / `JWT_AUDIENCE` / `JWT_ISSUER`: Optional Neon RLS JWKS configuration
+
+#### Caching
+- `REDIS_URL`: Traditional Redis connection string for local caching.
+- `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`: Upstash Redis REST credentials used for managed caching when provided.
+- `UPSTASH_REDIS_REST_READONLY_TOKEN`: Optional read-only Upstash token for safer GET-only operations.
 
 #### Feature Flags
 - `ENABLE_GDPR_FEATURES`: Enable GDPR compliance endpoints

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -27,8 +27,20 @@ class Settings(BaseSettings):
     DB_MAX_OVERFLOW: int = 0
     DB_POOL_RECYCLE: int = 300
 
-    # Redis
+    # Redis / Upstash
     REDIS_URL: str = Field(default="redis://localhost:6379/0")
+    UPSTASH_REDIS_REST_URL: Optional[str] = Field(
+        default=None,
+        description="Upstash Redis REST API endpoint",
+    )
+    UPSTASH_REDIS_REST_TOKEN: Optional[str] = Field(
+        default=None,
+        description="Upstash Redis REST API token with read/write permissions",
+    )
+    UPSTASH_REDIS_REST_READONLY_TOKEN: Optional[str] = Field(
+        default=None,
+        description="Optional Upstash Redis REST API token limited to read-only operations",
+    )
 
     # Security
     SECRET_KEY: str = Field(

--- a/src/backend/app/core/redis_client.py
+++ b/src/backend/app/core/redis_client.py
@@ -1,0 +1,74 @@
+"""Utility helpers for working with Upstash Redis."""
+from __future__ import annotations
+
+import asyncio
+from functools import lru_cache
+from typing import Optional
+
+import structlog
+from upstash_redis import Redis
+
+from app.core.config import get_settings
+
+logger = structlog.get_logger(__name__)
+
+
+def _get_upstash_credentials(read_only: bool) -> Optional[tuple[str, str]]:
+    """Return the configured Upstash credentials for the requested access level."""
+    settings = get_settings()
+
+    url = settings.UPSTASH_REDIS_REST_URL
+    if not url:
+        logger.debug("Upstash Redis URL not configured")
+        return None
+
+    if read_only:
+        token = settings.UPSTASH_REDIS_REST_READONLY_TOKEN or settings.UPSTASH_REDIS_REST_TOKEN
+    else:
+        token = settings.UPSTASH_REDIS_REST_TOKEN
+
+    if not token:
+        logger.debug("Upstash Redis token not configured", read_only=read_only)
+        return None
+
+    return url, token
+
+
+@lru_cache(maxsize=2)
+def get_upstash_redis_client(read_only: bool = False) -> Optional[Redis]:
+    """Create (and cache) an Upstash Redis client.
+
+    Parameters
+    ----------
+    read_only:
+        When ``True`` use the read-only API token if available. Falls back to the
+        read/write token when a dedicated read-only credential has not been
+        provided.
+    """
+
+    credentials = _get_upstash_credentials(read_only)
+    if credentials is None:
+        return None
+
+    url, token = credentials
+    logger.info("Initialising Upstash Redis client", read_only=read_only)
+    return Redis(url=url, token=token)
+
+
+async def flush_upstash_database() -> Optional[bool]:
+    """Flush the configured Upstash Redis database if credentials are present."""
+    client = get_upstash_redis_client(read_only=False)
+    if client is None:
+        return None
+
+    try:
+        await asyncio.to_thread(client.flushdb)
+        return True
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Failed to flush Upstash Redis database", error=str(exc))
+        return False
+
+
+def reset_upstash_client_cache() -> None:
+    """Reset cached Upstash clients (useful for tests)."""
+    get_upstash_redis_client.cache_clear()

--- a/src/backend/app/schemas/mollie_payment.py
+++ b/src/backend/app/schemas/mollie_payment.py
@@ -195,10 +195,8 @@ class MollieSubscriptionCreate(BaseModel):
             raise ValueError('Interval must start with a number')
 
         period = parts[1].lower()
-        if period not in {'day', 'days', 'week', 'weeks', 'month', 'months'}:
-            valid_periods = {'day', 'days', 'week', 'weeks', 'month', 'months'}
-
-        if parts[1] not in valid_periods:
+        valid_periods = {'day', 'days', 'week', 'weeks', 'month', 'months'}
+        if period not in valid_periods:
             raise ValueError('Interval period must be days, weeks, or months')
         return v
 

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -32,3 +32,4 @@ mollie-api-python==3.8.0
 python-multipart==0.0.9
 python-multipart>=0.0.9
 sib-api-v3-sdk==7.6.0
+upstash-redis==1.4.0

--- a/src/backend/tests/test_redis_client.py
+++ b/src/backend/tests/test_redis_client.py
@@ -1,0 +1,51 @@
+"""Tests for the Upstash Redis helper utilities."""
+from typing import Optional
+
+from upstash_redis import Redis
+
+from app.core import config
+from app.core.redis_client import (
+    get_upstash_redis_client,
+    reset_upstash_client_cache,
+)
+
+
+def _reset_settings_cache() -> None:
+    config.get_settings.cache_clear()
+
+
+def test_get_upstash_redis_client_returns_none_when_not_configured() -> None:
+    """Without credentials no client should be initialised."""
+    reset_upstash_client_cache()
+    _reset_settings_cache()
+
+    client = get_upstash_redis_client()
+
+    assert client is None
+
+
+def test_get_upstash_redis_client_uses_configuration(monkeypatch) -> None:
+    """When credentials are provided a Redis client instance is returned."""
+    monkeypatch.setenv("UPSTASH_REDIS_REST_URL", "https://example.upstash.io")
+    monkeypatch.setenv("UPSTASH_REDIS_REST_TOKEN", "test-token")
+    reset_upstash_client_cache()
+    _reset_settings_cache()
+
+    client: Optional[Redis] = get_upstash_redis_client()
+
+    assert client is not None
+    assert isinstance(client, Redis)
+
+
+def test_get_upstash_read_only_falls_back_to_write_token(monkeypatch) -> None:
+    """Read-only requests fall back to the primary token if a dedicated one is absent."""
+    monkeypatch.setenv("UPSTASH_REDIS_REST_URL", "https://example.upstash.io")
+    monkeypatch.setenv("UPSTASH_REDIS_REST_TOKEN", "test-token")
+    monkeypatch.delenv("UPSTASH_REDIS_REST_READONLY_TOKEN", raising=False)
+    reset_upstash_client_cache()
+    _reset_settings_cache()
+
+    client = get_upstash_redis_client(read_only=True)
+
+    assert client is not None
+    assert isinstance(client, Redis)


### PR DESCRIPTION
## Summary
- add Upstash Redis REST credentials to the backend settings and document the configuration
- introduce a reusable Upstash Redis client helper with tests and hook cache clearing into it
- fix the Mollie subscription interval validator bug uncovered while running the suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc4395330483309c50004977d8a4c4